### PR TITLE
♻️ refactor: chatgateway의 관심사 분리, 채팅 비즈니스 로직을 chatservice로 구현

### DIFF
--- a/server/src/chat/chat.gateway.ts
+++ b/server/src/chat/chat.gateway.ts
@@ -6,16 +6,8 @@ import {
   WebSocketServer,
 } from '@nestjs/websockets';
 import { Server, Socket } from 'socket.io';
-import { RedisService } from '../common/redis/redis.service';
 import { Injectable } from '@nestjs/common';
-import { getRandomNickname } from '@woowa-babble/random-nickname';
-import { Cron, CronExpression } from '@nestjs/schedule';
-
-const CLIENT_KEY_PREFIX = 'socket_client:';
-const CHAT_HISTORY_KEY = 'chat:history';
-const CHAT_HISTORY_LIMIT = 20;
-const CHAT_MIDNIGHT_CLIENT_NAME = 'system';
-const MAX_CLIENTS = 500;
+import { ChatService } from './chat.service';
 
 type BroadcastPayload = {
   username: string;
@@ -33,30 +25,12 @@ type BroadcastPayload = {
 export class ChatGateway implements OnGatewayConnection, OnGatewayDisconnect {
   @WebSocketServer()
   server: Server;
-  private dayInit: boolean = false;
 
-  constructor(private readonly redisService: RedisService) {}
-
-  @Cron(CronExpression.EVERY_DAY_AT_MIDNIGHT)
-  private midnightInitializer() {
-    this.dayInit = true;
-  }
-
-  private async emitMidnightMessage() {
-    const broadcastPayload: BroadcastPayload = {
-      username: CHAT_MIDNIGHT_CLIENT_NAME,
-      message: '',
-      timestamp: new Date(),
-    };
-
-    await this.saveMessageToRedis(broadcastPayload);
-
-    this.server.emit('message', broadcastPayload);
-  }
+  constructor(private readonly chatService: ChatService) {}
 
   async handleConnection(client: Socket) {
     const userCount = this.server.engine.clientsCount;
-    if (userCount > MAX_CLIENTS) {
+    if (await this.chatService.isMaxClientExceeded(userCount)) {
       client.emit('maximum_exceeded', {
         message: '채팅 서버의 한계에 도달했습니다. 잠시후 재시도 해주세요.',
       });
@@ -64,14 +38,8 @@ export class ChatGateway implements OnGatewayConnection, OnGatewayDisconnect {
       return;
     }
 
-    const ip = this.getIp(client);
-    const clientName = await this.getOrSetClientNameByIp(ip);
-    const recentMessages = await this.redisService.redisClient.lrange(
-      CHAT_HISTORY_KEY,
-      0,
-      CHAT_HISTORY_LIMIT - 1,
-    );
-    const chatHistory = recentMessages.map((msg) => JSON.parse(msg)).reverse();
+    const clientName = await this.chatService.getOrSetClientNameByIp(client);
+    const chatHistory = await this.chatService.getChatHistory();
 
     client.emit('chatHistory', chatHistory);
 
@@ -89,9 +57,7 @@ export class ChatGateway implements OnGatewayConnection, OnGatewayDisconnect {
 
   @SubscribeMessage('message')
   async handleMessage(client: Socket, payload: { message: string }) {
-    const ip = this.getIp(client);
-    const redisKey = CLIENT_KEY_PREFIX + ip;
-    const clientName = await this.redisService.redisClient.get(redisKey);
+    const clientName = await this.chatService.getOrSetClientNameByIp(client);
 
     const broadcastPayload: BroadcastPayload = {
       username: clientName,
@@ -99,59 +65,12 @@ export class ChatGateway implements OnGatewayConnection, OnGatewayDisconnect {
       timestamp: new Date(),
     };
 
-    await this.saveMessageToRedis(broadcastPayload);
+    await this.chatService.saveMessageToRedis(broadcastPayload);
 
-    if (this.dayInit) {
-      this.dayInit = false;
-      await this.emitMidnightMessage();
+    const midnightMessage = await this.chatService.handleDateMessage();
+    if (midnightMessage) {
+      this.server.emit('message', midnightMessage);
     }
-
     this.server.emit('message', broadcastPayload);
-  }
-
-  private getIp(client: Socket) {
-    const forwardedFor = client.handshake.headers['x-forwarded-for'] as string;
-    const ip = forwardedFor
-      ? forwardedFor.split(',')[0].trim()
-      : client.handshake.address;
-
-    return ip;
-  }
-
-  private async getOrSetClientNameByIp(ip: string) {
-    const redisKey = CLIENT_KEY_PREFIX + ip;
-    let clientName: string = await this.redisService.redisClient.get(redisKey);
-
-    if (clientName) {
-      return clientName;
-    }
-
-    clientName = this.generateRandomUsername();
-    await this.redisService.redisClient.set(
-      redisKey,
-      clientName,
-      'EX',
-      3600 * 24,
-    );
-    return clientName;
-  }
-
-  private generateRandomUsername(): string {
-    const type = 'animals';
-
-    return getRandomNickname(type);
-  }
-
-  private async saveMessageToRedis(payload: BroadcastPayload) {
-    await this.redisService.redisClient.lpush(
-      CHAT_HISTORY_KEY,
-      JSON.stringify(payload),
-    );
-
-    await this.redisService.redisClient.ltrim(
-      CHAT_HISTORY_KEY,
-      0,
-      CHAT_HISTORY_LIMIT - 1,
-    );
   }
 }

--- a/server/src/chat/chat.gateway.ts
+++ b/server/src/chat/chat.gateway.ts
@@ -30,7 +30,7 @@ export class ChatGateway implements OnGatewayConnection, OnGatewayDisconnect {
 
   async handleConnection(client: Socket) {
     const userCount = this.server.engine.clientsCount;
-    if (await this.chatService.isMaxClientExceeded(userCount)) {
+    if (this.chatService.isMaxClientExceeded(userCount)) {
       client.emit('maximum_exceeded', {
         message: '채팅 서버의 한계에 도달했습니다. 잠시후 재시도 해주세요.',
       });

--- a/server/src/chat/chat.gateway.ts
+++ b/server/src/chat/chat.gateway.ts
@@ -38,7 +38,7 @@ export class ChatGateway implements OnGatewayConnection, OnGatewayDisconnect {
       return;
     }
 
-    const clientName = await this.chatService.getOrSetClientNameByIp(client);
+    const clientName = await this.chatService.getClientNameByIp(client);
     const chatHistory = await this.chatService.getChatHistory();
 
     client.emit('chatHistory', chatHistory);
@@ -57,7 +57,7 @@ export class ChatGateway implements OnGatewayConnection, OnGatewayDisconnect {
 
   @SubscribeMessage('message')
   async handleMessage(client: Socket, payload: { message: string }) {
-    const clientName = await this.chatService.getOrSetClientNameByIp(client);
+    const clientName = await this.chatService.getClientNameByIp(client);
 
     const broadcastPayload: BroadcastPayload = {
       username: clientName,

--- a/server/src/chat/chat.gateway.ts
+++ b/server/src/chat/chat.gateway.ts
@@ -65,12 +65,11 @@ export class ChatGateway implements OnGatewayConnection, OnGatewayDisconnect {
       timestamp: new Date(),
     };
 
-    await this.chatService.saveMessageToRedis(broadcastPayload);
-
     const midnightMessage = await this.chatService.handleDateMessage();
     if (midnightMessage) {
       this.server.emit('message', midnightMessage);
     }
+    await this.chatService.saveMessageToRedis(broadcastPayload);
     this.server.emit('message', broadcastPayload);
   }
 }

--- a/server/src/chat/chat.module.ts
+++ b/server/src/chat/chat.module.ts
@@ -1,9 +1,10 @@
 import { Module } from '@nestjs/common';
 import { ChatGateway } from './chat.gateway';
 import { ScheduleModule } from '@nestjs/schedule';
+import { ChatService } from './chat.service';
 
 @Module({
   imports: [ScheduleModule.forRoot()],
-  providers: [ChatGateway],
+  providers: [ChatGateway, ChatService],
 })
 export class ChatModule {}

--- a/server/src/chat/chat.service.ts
+++ b/server/src/chat/chat.service.ts
@@ -35,22 +35,22 @@ export class ChatService {
     return ip;
   }
 
-  async getOrSetClientNameByIp(client: Socket) {
+  async getClientNameByIp(client: Socket) {
     const ip = this.getClientIp(client);
     const redisKey = CLIENT_KEY_PREFIX + ip;
-    const clientName: string = await this.getClientNameByIp(redisKey);
+    const clientName: string = await this.getClientName(redisKey);
     if (clientName) {
       return clientName;
     }
-    const createdClientName = this.setClientNameByIp(redisKey);
+    const createdClientName = this.setClientName(redisKey);
     return createdClientName;
   }
 
-  private async getClientNameByIp(redisKey: string) {
+  private async getClientName(redisKey: string) {
     return await this.redisService.redisClient.get(redisKey);
   }
 
-  private async setClientNameByIp(redisKey: string) {
+  private async setClientName(redisKey: string) {
     const clientName = this.generateRandomUsername();
     await this.redisService.redisClient.set(
       redisKey,

--- a/server/src/chat/chat.service.ts
+++ b/server/src/chat/chat.service.ts
@@ -42,7 +42,7 @@ export class ChatService {
     if (clientName) {
       return clientName;
     }
-    const createdClientName = this.setClientName(redisKey);
+    const createdClientName = await this.setClientName(redisKey);
     return createdClientName;
   }
 

--- a/server/src/chat/chat.service.ts
+++ b/server/src/chat/chat.service.ts
@@ -1,0 +1,120 @@
+import { Injectable } from '@nestjs/common';
+import { Socket } from 'socket.io';
+import { RedisService } from '../common/redis/redis.service';
+import { getRandomNickname } from '@woowa-babble/random-nickname';
+import { Cron, CronExpression } from '@nestjs/schedule';
+
+const MAX_CLIENTS = 500;
+const CLIENT_KEY_PREFIX = 'socket_client:';
+const CHAT_HISTORY_KEY = 'chat:history';
+const CHAT_HISTORY_LIMIT = 20;
+const CHAT_MIDNIGHT_CLIENT_NAME = 'system';
+
+type BroadcastPayload = {
+  username: string;
+  message: string;
+  timestamp: Date;
+};
+
+@Injectable()
+export class ChatService {
+  private dayInit: boolean = false;
+
+  constructor(private readonly redisService: RedisService) {}
+
+  async isMaxClientExceeded(userCount: number) {
+    return userCount > MAX_CLIENTS;
+  }
+
+  private getClientIp(client: Socket) {
+    const forwardedFor = client.handshake.headers['x-forwarded-for'] as string;
+    const ip = forwardedFor
+      ? forwardedFor.split(',')[0].trim()
+      : client.handshake.address;
+
+    return ip;
+  }
+
+  async getOrSetClientNameByIp(client: Socket) {
+    const ip = this.getClientIp(client);
+    const redisKey = CLIENT_KEY_PREFIX + ip;
+    const clientName: string = await this.getClientNameByIp(redisKey);
+    if (clientName) {
+      return clientName;
+    }
+    const createdClientName = this.setClientNameByIp(redisKey);
+    return createdClientName;
+  }
+
+  private async getClientNameByIp(redisKey: string) {
+    return await this.redisService.redisClient.get(redisKey);
+  }
+
+  private async setClientNameByIp(redisKey: string) {
+    const clientName = this.generateRandomUsername();
+    await this.redisService.redisClient.set(
+      redisKey,
+      clientName,
+      'EX',
+      3600 * 24,
+    );
+    return clientName;
+  }
+
+  private generateRandomUsername(): string {
+    const type = 'animals';
+
+    return getRandomNickname(type);
+  }
+
+  async getChatHistory() {
+    return (await this.getRecentChatMessages())
+      .map((msg) => JSON.parse(msg))
+      .reverse();
+  }
+
+  private async getRecentChatMessages() {
+    return await this.redisService.redisClient.lrange(
+      CHAT_HISTORY_KEY,
+      0,
+      CHAT_HISTORY_LIMIT - 1,
+    );
+  }
+
+  async saveMessageToRedis(payload: BroadcastPayload) {
+    await this.redisService.redisClient.lpush(
+      CHAT_HISTORY_KEY,
+      JSON.stringify(payload),
+    );
+
+    await this.redisService.redisClient.ltrim(
+      CHAT_HISTORY_KEY,
+      0,
+      CHAT_HISTORY_LIMIT - 1,
+    );
+  }
+
+  async saveDateMessage() {
+    const broadcastPayload: BroadcastPayload = {
+      username: CHAT_MIDNIGHT_CLIENT_NAME,
+      message: '',
+      timestamp: new Date(),
+    };
+
+    await this.saveMessageToRedis(broadcastPayload);
+
+    return broadcastPayload;
+  }
+
+  async handleDateMessage() {
+    if (this.dayInit) {
+      this.dayInit = false;
+      return await this.saveDateMessage();
+    }
+  }
+
+  @Cron(CronExpression.EVERY_DAY_AT_MIDNIGHT)
+  private midnightInitializer() {
+    this.dayInit = true;
+  }
+}

--- a/server/src/chat/chat.service.ts
+++ b/server/src/chat/chat.service.ts
@@ -22,7 +22,7 @@ export class ChatService {
 
   constructor(private readonly redisService: RedisService) {}
 
-  async isMaxClientExceeded(userCount: number) {
+  isMaxClientExceeded(userCount: number) {
     return userCount > MAX_CLIENTS;
   }
 


### PR DESCRIPTION
# 🔨 테스크

### chatgateway의 관심사 분리
- 기존의 chatgateway에는 여러 책임이 있었습니다.
  - 소켓 연결 관리
  - 메세지 이벤트 핸들링
  - Redis에 메세지 저장
  - 날짜가 바뀌었을 때 보낼 시스템 메세지 핸들링
  - 클라이언트의 IP를 확인하고 이름 생성 혹은 저장된 이름 가져오기
  - 채팅 내역 불러오기

- gateway는 소켓 연결 관리와 메세지 이벤트 핸들링, 2가지의 책임을 지도록 관심사를 분리했습니다.
- 이렇게 함으로써 기존 코드보다 유지보수와 확장에 이점을 가질 수 있다고 생각했습니다.
- 나중에 service 레이어도 비대해지면 Redis와 관련된 부분을 모두 추출하여, repository 계층으로 분리할 수 있을 것 같습니다.

# 📋 작업 내용

- gateway 내부에서 비즈니스 로직을 모두 service 레이어로 추출
- service 레이어로 추출하면서 메서드 이름, 접근 제한자 종류를 조금씩 수정했습니다.
  - ex) `emitMidnightMessage` 같은 메서드는 `handleDateMessage`로 수정, `getIp`는 클라이언트 이름 설정에만 쓰이기에 private 전환 등...

# 📷 스크린 샷(선택 사항)
![스크린샷 2025-01-07 171256](https://github.com/user-attachments/assets/5b788454-7844-46ad-9e6e-903706eb0eb8)
![스크린샷 2025-01-07 171311](https://github.com/user-attachments/assets/3ec04c01-1cc2-4b0f-a53d-8bc93553bc9f)