### PR TITLE
♻️ refactor: 데이터 전처리 Repository 계층으로 위임

### DIFF
--- a/server/src/rss/service/feed-crawler.service.ts
+++ b/server/src/rss/service/feed-crawler.service.ts
@@ -3,6 +3,7 @@ import { XMLParser } from 'fast-xml-parser';
 import { FeedRepository } from '../../feed/repository/feed.repository';
 import { RssParserService } from '../service/rss-parser.service';
 import { Feed } from '../../feed/entity/feed.entity';
+import { RssAccept } from '../entity/rss.entity';
 
 @Injectable()
 export class FeedCrawlerService {
@@ -15,7 +16,8 @@ export class FeedCrawlerService {
     return await this.fetchRss(rssUrl);
   }
 
-  async saveRssFeeds(feeds: Partial<Feed>[]) {
+  async saveRssFeeds(feeds: Partial<Feed>[], newRssAccept: RssAccept) {
+    feeds.forEach((feed) => (feed.blog = newRssAccept));
     return await this.feedRepository.insert(feeds);
   }
 

--- a/server/src/rss/service/rss.service.ts
+++ b/server/src/rss/service/rss.service.ts
@@ -74,11 +74,10 @@ export class RssService {
         const feeds = await this.feedCrawlerService.loadRssFeeds(
           newRssAccept.rssUrl,
         );
-        feeds.forEach((feed) => (feed.blog = newRssAccept));
         return [newRssAccept, feeds];
       },
     );
-    await this.feedCrawlerService.saveRssFeeds(feeds);
+    await this.feedCrawlerService.saveRssFeeds(feeds, newRssAccept);
     this.emailService.sendMail(newRssAccept, true);
   }
 


### PR DESCRIPTION
# 🔨 테스크

### 데이터 전처리(TypeORM 엔티티 매핑) Repository vs Service?
함께 토론 해주신 @asn6878 @CodeVac513 감사드립니다!!

- Repository 파
    - TypeORM 엔티티와 매핑하는 행위는 비즈니스 로직보다 DB와 더 밀접한 연관이 있다.
    - Service 계층이 비대해지면 비즈니스 로직 파악이 어렵다.

- Service 파
    - 예외 경우가 있을 수 있다. ex) "loadRssFeeds의 글 작성자(feed.blog)는 newRssAccept이다.' 라는 것을 DB 입장에서도 볼 수 있지만, 서비스 입장에서도 보면 작성자를 대입해주는 것이기에 비즈니스 로직이다.
   - 레포지토리 계층은 간단하게 처리할 수록 재사용 가능성이 생긴다.

결론
1. GPT를 사용해서 답을 찾아도 GPT 가스라이팅 하면 그대로 답이 나오기 때문에 의미가 없다.
2. 그러므로 팀 내에서 결정한다.
3. 정답은 없고, 나중에 어떻게 될지 모르기 때문에 우선은 작업자의 선택에 따른다. -> Repository 계층에서 TypeORM 매핑, 전처리 수행

# 📋 작업 내용

-   RSS 승인시 데이터 전처리 부분 Repository 계층으로 위임
