### PR TITLE
♻️ refactor: Redis 동작 메서드 캡슐화

### DIFF
--- a/feed-crawler/src/common/redis-access.ts
+++ b/feed-crawler/src/common/redis-access.ts
@@ -1,12 +1,14 @@
 import Redis from "ioredis";
 import logger from "../common/logger";
 import * as dotenv from "dotenv";
+import {injectable} from "tsyringe";
 
 dotenv.config({
   path: process.env.NODE_ENV === "production" ? "feed-crawler/.env" : ".env",
 });
 
-class RedisConnection {
+@injectable()
+export class RedisConnection {
   private redis: Redis;
   private nameTag: string;
 
@@ -41,5 +43,3 @@ class RedisConnection {
     return this.redis;
   }
 }
-
-export const redisConnection = new RedisConnection();

--- a/feed-crawler/src/common/redis-access.ts
+++ b/feed-crawler/src/common/redis-access.ts
@@ -1,4 +1,4 @@
-import Redis from "ioredis";
+import Redis, {ChainableCommander} from "ioredis";
 import logger from "../common/logger";
 import * as dotenv from "dotenv";
 import {injectable} from "tsyringe";
@@ -39,7 +39,36 @@ export class RedisConnection {
     }
   }
 
-  get command() {
-    return this.redis;
+  async del(...keys: string[]){
+    this.redis.del(...keys);
+  }
+
+  async scan(pattern: string, count: number = 100): Promise<string[]> {
+    let cursor = "0";
+    const resultKeys: string[] = [];
+
+    do {
+      const [newCursor, keys] = await this.redis.scan(cursor, "MATCH", pattern, "COUNT",  count.toString())
+      resultKeys.push(...keys);
+      cursor = newCursor;
+    } while (cursor !== "0");
+
+    return resultKeys;
+  }
+
+  async executePipeline(commands: (pipeline: ChainableCommander) => void) {
+    const pipeline = this.redis.pipeline();
+    try {
+      commands(pipeline);
+      const results = await pipeline.exec();
+      return results;
+    } catch (error) {
+      logger.error(
+          `${this.nameTag} 파이프라인 실행 중 오류 발생:
+        메시지: ${error.message}
+        스택 트레이스: ${error.stack}`
+      );
+      throw error;
+    }
   }
 }

--- a/feed-crawler/src/container.ts
+++ b/feed-crawler/src/container.ts
@@ -4,8 +4,10 @@ import { DEPENDENCY_SYMBOLS } from "./types/dependency-symbols";
 import {MySQLConnection} from "./common/mysql-access";
 import {RssRepository} from "./repository/rss.repository";
 import {FeedRepository} from "./repository/feed.repository";
+import {RedisConnection} from "./common/redis-access";
 
 container.registerSingleton<DatabaseConnection>(DEPENDENCY_SYMBOLS.DatabaseConnection, MySQLConnection);
+container.registerSingleton<RedisConnection>(DEPENDENCY_SYMBOLS.RedisConnection, RedisConnection);
 
 container.registerSingleton<RssRepository>(DEPENDENCY_SYMBOLS.RssRepository, RssRepository);
 container.registerSingleton<FeedRepository>(DEPENDENCY_SYMBOLS.FeedRepository, FeedRepository);

--- a/feed-crawler/src/repository/feed.repository.ts
+++ b/feed-crawler/src/repository/feed.repository.ts
@@ -1,14 +1,19 @@
 import { FeedDetail } from "../common/types";
 import logger from "../common/logger";
 import { redisConstant } from "../common/constant";
-import {RedisConnection} from "../common/redis-access";
-import {inject, injectable} from "tsyringe";
-import {DEPENDENCY_SYMBOLS} from "../types/dependency-symbols";
-import {DatabaseConnection} from "../types/database-connection";
+import { RedisConnection } from "../common/redis-access";
+import { inject, injectable } from "tsyringe";
+import { DEPENDENCY_SYMBOLS } from "../types/dependency-symbols";
+import { DatabaseConnection } from "../types/database-connection";
 
 @injectable()
 export class FeedRepository {
-  constructor(@inject(DEPENDENCY_SYMBOLS.DatabaseConnection) private readonly dbConnection: DatabaseConnection, @inject(DEPENDENCY_SYMBOLS.RedisConnection) private readonly redisConnection: RedisConnection) {};
+  constructor(
+    @inject(DEPENDENCY_SYMBOLS.DatabaseConnection)
+    private readonly dbConnection: DatabaseConnection,
+    @inject(DEPENDENCY_SYMBOLS.RedisConnection)
+    private readonly redisConnection: RedisConnection,
+  ) {}
 
   public async insertFeeds(resultData: FeedDetail[]) {
     const query = `
@@ -41,7 +46,7 @@ export class FeedRepository {
       .filter((result) => result);
 
     logger.info(
-      `[MySQL] ${insertedFeeds.length}개의 피드 데이터가 성공적으로 데이터베이스에 삽입되었습니다.`
+      `[MySQL] ${insertedFeeds.length}개의 피드 데이터가 성공적으로 데이터베이스에 삽입되었습니다.`,
     );
     return insertedFeeds;
   }
@@ -49,7 +54,18 @@ export class FeedRepository {
   async deleteRecentFeed() {
     try {
       this.redisConnection.connect();
-      const keysToDelete = await this.redisConnection.scan(redisConstant.FEED_RECENT_ALL_KEY);
+
+      const keysToDelete = [];
+      let cursor = "0";
+      do {
+        const [newCursor, keys] = await this.redisConnection.scan(
+          cursor,
+          redisConstant.FEED_RECENT_ALL_KEY,
+          100,
+        );
+        keysToDelete.push(...keys);
+        cursor = newCursor;
+      } while (cursor !== "0");
 
       if (keysToDelete.length > 0) {
         await this.redisConnection.del(...keysToDelete);
@@ -58,7 +74,7 @@ export class FeedRepository {
       logger.error(
         `[Redis] 최근 게시글 캐시를 삭제하는 도중 에러가 발생했습니다.
         에러 메시지: ${error.message}
-        스택 트레이스: ${error.stack}`
+        스택 트레이스: ${error.stack}`,
       );
     } finally {
       await this.redisConnection.quit();
@@ -84,9 +100,9 @@ export class FeedRepository {
       });
     } catch (error) {
       logger.error(
-          `[Redis] 최근 게시글 캐시를 저장하는 도중 에러가 발생했습니다.
+        `[Redis] 최근 게시글 캐시를 저장하는 도중 에러가 발생했습니다.
         에러 메시지: ${error.message}
-        스택 트레이스: ${error.stack}`
+        스택 트레이스: ${error.stack}`,
       );
     } finally {
       await this.redisConnection.quit();

--- a/feed-crawler/src/types/dependency-symbols.ts
+++ b/feed-crawler/src/types/dependency-symbols.ts
@@ -2,4 +2,5 @@ export const DEPENDENCY_SYMBOLS = {
     DatabaseConnection: Symbol.for("DatabaseConnection"),
     RssRepository: Symbol.for("RssRepository"),
     FeedRepository: Symbol.for("FeedRepository"),
+    RedisConnection: Symbol.for("RedisConnection"),
 }

--- a/server/src/chat/service/chat.service.ts
+++ b/server/src/chat/service/chat.service.ts
@@ -40,17 +40,12 @@ export class ChatService {
   }
 
   private async getClientName(redisKey: string) {
-    return await this.redisService.redisClient.get(redisKey);
+    return await this.redisService.get(redisKey);
   }
 
   private async setClientName(redisKey: string) {
     const clientName = this.generateRandomUsername();
-    await this.redisService.redisClient.set(
-      redisKey,
-      clientName,
-      'EX',
-      3600 * 24,
-    );
+    await this.redisService.set(redisKey, clientName, 'EX', 3600 * 24);
     return clientName;
   }
 
@@ -67,7 +62,7 @@ export class ChatService {
   }
 
   private async getRecentChatMessages() {
-    return await this.redisService.redisClient.lrange(
+    return await this.redisService.lrange(
       CHAT_HISTORY_KEY,
       0,
       CHAT_HISTORY_LIMIT - 1,
@@ -75,15 +70,8 @@ export class ChatService {
   }
 
   async saveMessageToRedis(payload: BroadcastPayload) {
-    await this.redisService.redisClient.lpush(
-      CHAT_HISTORY_KEY,
-      JSON.stringify(payload),
-    );
+    await this.redisService.lpush(CHAT_HISTORY_KEY, JSON.stringify(payload));
 
-    await this.redisService.redisClient.ltrim(
-      CHAT_HISTORY_KEY,
-      0,
-      CHAT_HISTORY_LIMIT - 1,
-    );
+    await this.redisService.ltrim(CHAT_HISTORY_KEY, 0, CHAT_HISTORY_LIMIT - 1);
   }
 }

--- a/server/src/common/guard/auth.guard.ts
+++ b/server/src/common/guard/auth.guard.ts
@@ -14,7 +14,7 @@ export class CookieAuthGuard implements CanActivate {
   async canActivate(context: ExecutionContext): Promise<boolean> {
     const request = context.switchToHttp().getRequest<Request>();
     const sid = request.cookies['sessionId'];
-    const loginId = await this.redisService.redisClient.get(`auth:${sid}`);
+    const loginId = await this.redisService.get(`auth:${sid}`);
     if (!loginId) {
       throw new UnauthorizedException('인증되지 않은 요청입니다.');
     }

--- a/server/src/common/redis/redis.service.ts
+++ b/server/src/common/redis/redis.service.ts
@@ -1,7 +1,115 @@
 import { Inject, Injectable } from '@nestjs/common';
-import Redis from 'ioredis';
+import Redis, { ChainableCommander } from 'ioredis';
+import { Callback } from 'ioredis/built/types';
+import { RedisKey } from 'ioredis/built/utils/RedisCommander';
 
 @Injectable()
 export class RedisService {
   constructor(@Inject('REDIS_CLIENT') public readonly redisClient: Redis) {}
+
+  async get(key: RedisKey): Promise<string | null> {
+    return this.redisClient.get(key);
+  }
+
+  async set(
+    key: string,
+    value: string | number,
+    ...args: any[]
+  ): Promise<'OK' | null> {
+    return this.redisClient.set(key, value, ...args);
+  }
+
+  async del(...keys: string[]): Promise<number> {
+    return this.redisClient.del(...keys);
+  }
+
+  async keys(pattern: string): Promise<string[]> {
+    return this.redisClient.keys(pattern);
+  }
+
+  async scan(
+    cursor: string | number,
+    match?: string,
+    count?: number,
+  ): Promise<[cursor: string, keys: string[]]> {
+    const result = await this.redisClient.scan(
+      cursor,
+      'MATCH',
+      match || '*',
+      'COUNT',
+      count || 10,
+    );
+    return [result[0], result[1]];
+  }
+
+  async mget(...keys: string[]): Promise<(string | null)[]> {
+    return this.redisClient.mget(...keys);
+  }
+
+  async lrange(
+    key: string,
+    start: number | string,
+    stop: number | string,
+  ): Promise<string[]> {
+    return this.redisClient.lrange(key, start, stop);
+  }
+
+  async lpush(key: string, ...values: string[]): Promise<number> {
+    return this.redisClient.lpush(key, ...values);
+  }
+
+  async zrevrange(
+    key: string,
+    start: number,
+    stop: number,
+    withScores: 'WITHSCORES',
+  ): Promise<string[]> {
+    if (withScores) {
+      return this.redisClient.zrevrange(key, start, stop, 'WITHSCORES');
+    }
+    return this.redisClient.zrevrange(key, start, stop);
+  }
+
+  async executePipeline(commands: (pipeline: ChainableCommander) => void) {
+    const pipeline = this.redisClient.pipeline();
+    commands(pipeline);
+    const results = await pipeline.exec();
+
+    return results;
+  }
+
+  async ltrim(
+    key: string,
+    start: number | string,
+    stop: number | string,
+  ): Promise<string> {
+    return this.redisClient.ltrim(key, start, stop);
+  }
+
+  async sadd(key: string, ...members: string[] | number[]): Promise<number> {
+    return this.redisClient.sadd(key, ...members);
+  }
+
+  async zadd(
+    key: string,
+    ...scoreMembers: (string | Buffer | number)[]
+  ): Promise<number> {
+    return this.redisClient.zadd(key, ...scoreMembers);
+  }
+
+  async zscore(key: string, member: string): Promise<string | null> {
+    return this.redisClient.zscore(key, member);
+  }
+
+  async zrem(key: string, ...members: string[]): Promise<number> {
+    return this.redisClient.zrem(key, ...members);
+  }
+
+  async srem(key: string, ...members: string[]): Promise<number> {
+    return this.redisClient.srem(key, ...members);
+  }
+
+  async flushdb(): Promise<string> {
+    return this.redisClient.flushdb();
+  }
 }

--- a/server/src/common/redis/redis.service.ts
+++ b/server/src/common/redis/redis.service.ts
@@ -115,4 +115,16 @@ export class RedisService {
   async flushdb(): Promise<string> {
     return this.redisClient.flushdb();
   }
+
+  async sismember(key: string, member: string | number): Promise<number> {
+    return this.redisClient.sismember(key, member);
+  }
+
+  async zincrby(
+    key: string,
+    increment: number | string,
+    member: string | number,
+  ): Promise<string> {
+    return this.redisClient.zincrby(key, increment, member);
+  }
 }

--- a/server/src/common/redis/redis.service.ts
+++ b/server/src/common/redis/redis.service.ts
@@ -1,6 +1,5 @@
 import { Inject, Injectable } from '@nestjs/common';
 import Redis, { ChainableCommander } from 'ioredis';
-import { Callback } from 'ioredis/built/types';
 import { RedisKey } from 'ioredis/built/utils/RedisCommander';
 
 @Injectable()
@@ -54,15 +53,19 @@ export class RedisService {
     return this.redisClient.lrange(key, start, stop);
   }
 
-  async lpush(key: string, ...values: string[]): Promise<number> {
+  async lpush(key: string, ...values: (string | number)[]): Promise<number> {
     return this.redisClient.lpush(key, ...values);
+  }
+
+  async rpush(key: string, ...values: (string | number)[]): Promise<number> {
+    return this.redisClient.rpush(key, ...values);
   }
 
   async zrevrange(
     key: string,
     start: number,
     stop: number,
-    withScores: 'WITHSCORES',
+    withScores?: 'WITHSCORES',
   ): Promise<string[]> {
     if (withScores) {
       return this.redisClient.zrevrange(key, start, stop, 'WITHSCORES');

--- a/server/src/feed/service/feed.service.ts
+++ b/server/src/feed/service/feed.service.ts
@@ -58,7 +58,7 @@ export class FeedService {
 
   private async checkNewFeeds(feedList: FeedView[]) {
     const newFeedIds = (
-      await this.redisService.redisClient.keys(redisKeys.FEED_RECENT_ALL_KEY)
+      await this.redisService.keys(redisKeys.FEED_RECENT_ALL_KEY)
     ).map((key) => {
       const id = key.match(/feed:recent:(\d+)/);
       return parseInt(id[1]);
@@ -73,7 +73,7 @@ export class FeedService {
   }
 
   async readTrendFeedList() {
-    const trendFeedIdList = await this.redisService.redisClient.lrange(
+    const trendFeedIdList = await this.redisService.lrange(
       redisKeys.FEED_ORIGIN_TREND_KEY,
       0,
       -1,
@@ -117,6 +117,7 @@ export class FeedService {
     return searchType.hasOwnProperty(type);
   }
 
+  // 여기 안쓰는 함수 추가요~
   async updateFeedViewCount(
     feedId: number,
     request: Request,
@@ -125,11 +126,10 @@ export class FeedService {
     const cookie = request.headers.cookie;
     const ip = this.getIp(request);
     if (ip && this.isString(ip)) {
-      const redis = this.redisService.redisClient;
       const [feed, hasCookie, hasIpFlag] = await Promise.all([
         this.feedRepository.findOne({ where: { id: feedId } }),
         Boolean(cookie?.includes(`View_count_${feedId}=${feedId}`)),
-        redis.sismember(`feed:${feedId}:ip`, ip),
+        this.redisService.redisClient.sismember(`feed:${feedId}:ip`, ip),
       ]);
 
       if (!feed) {
@@ -145,11 +145,15 @@ export class FeedService {
       }
 
       await Promise.all([
-        redis.sadd(`feed:${feedId}:ip`, ip),
+        this.redisService.sadd(`feed:${feedId}:ip`, ip),
         this.feedRepository.update(feedId, {
           viewCount: () => 'view_count + 1',
         }),
-        redis.zincrby(redisKeys.FEED_TREND_KEY, 1, feedId.toString()),
+        this.redisService.redisClient.zincrby(
+          redisKeys.FEED_TREND_KEY,
+          1,
+          feedId.toString(),
+        ),
       ]);
     }
   }
@@ -175,19 +179,21 @@ export class FeedService {
   }
 
   async readRecentFeedList() {
-    const redis = this.redisService.redisClient;
-    const recentKeys = await redis.keys(redisKeys.FEED_RECENT_ALL_KEY);
+    const recentKeys = await this.redisService.keys(
+      redisKeys.FEED_RECENT_ALL_KEY,
+    );
     const recentFeedList: FeedPaginationResult[] = [];
 
     if (!recentKeys.length) {
       return recentFeedList;
     }
 
-    const pipeLine = redis.pipeline();
-    for (const key of recentKeys) {
-      pipeLine.hgetall(key);
-    }
-    const result = await pipeLine.exec();
+    const result = await this.redisService.executePipeline((pipeline) => {
+      for (const key of recentKeys) {
+        pipeline.hgetall(key);
+      }
+    });
+
     recentFeedList.push(
       ...result.map(([, feed]: [any, FeedPaginationResult]) => {
         feed.isNew = true;

--- a/server/src/feed/service/feed.service.ts
+++ b/server/src/feed/service/feed.service.ts
@@ -117,7 +117,6 @@ export class FeedService {
     return searchType.hasOwnProperty(type);
   }
 
-  // 여기 안쓰는 함수 추가요~
   async updateFeedViewCount(
     feedId: number,
     request: Request,
@@ -129,7 +128,7 @@ export class FeedService {
       const [feed, hasCookie, hasIpFlag] = await Promise.all([
         this.feedRepository.findOne({ where: { id: feedId } }),
         Boolean(cookie?.includes(`View_count_${feedId}=${feedId}`)),
-        this.redisService.redisClient.sismember(`feed:${feedId}:ip`, ip),
+        this.redisService.sismember(`feed:${feedId}:ip`, ip),
       ]);
 
       if (!feed) {
@@ -149,7 +148,7 @@ export class FeedService {
         this.feedRepository.update(feedId, {
           viewCount: () => 'view_count + 1',
         }),
-        this.redisService.redisClient.zincrby(
+        this.redisService.zincrby(
           redisKeys.FEED_TREND_KEY,
           1,
           feedId.toString(),

--- a/server/src/statistic/service/statistic.service.ts
+++ b/server/src/statistic/service/statistic.service.ts
@@ -13,7 +13,7 @@ export class StatisticService {
     private readonly rssAcceptRepository: RssAcceptRepository,
   ) {}
   async readTodayStatistic(limit: number) {
-    const ranking = await this.redisService.redisClient.zrevrange(
+    const ranking = await this.redisService.zrevrange(
       redisKeys.FEED_TREND_KEY,
       0,
       limit - 1,

--- a/server/test/admin/e2e/logout.e2e-spec.ts
+++ b/server/test/admin/e2e/logout.e2e-spec.ts
@@ -8,7 +8,7 @@ describe('POST /api/admin/logout E2E Test', () => {
   beforeAll(async () => {
     app = global.testApp;
     const redisService = app.get(RedisService);
-    await redisService.redisClient.sadd('auth:sid', 'test1234');
+    await redisService.sadd('auth:sid', 'test1234');
   });
 
   it('관리자 로그인이 되어 있으면 로그아웃을 정상적으로 할 수 있다.', async () => {

--- a/server/test/feed/e2e/feedId.e2e-spec.ts
+++ b/server/test/feed/e2e/feedId.e2e-spec.ts
@@ -30,7 +30,7 @@ describe('POST /api/feed/:feedId E2E Test', () => {
 
     await Promise.all([
       feedRepository.save(feeds),
-      redisService.redisClient.sadd(`feed:${testFeedId}:ip`, testIp),
+      redisService.sadd(`feed:${testFeedId}:ip`, testIp),
     ]);
   });
 
@@ -44,7 +44,7 @@ describe('POST /api/feed/:feedId E2E Test', () => {
         .post(`/api/feed/${testFeedId}`)
         .set('X-Forwarded-For', testNewIp);
       const feedDailyViewCount = parseInt(
-        await redisService.redisClient.zscore(
+        await redisService.zscore(
           redisKeys.FEED_TREND_KEY,
           testFeedId.toString(),
         ),
@@ -59,11 +59,8 @@ describe('POST /api/feed/:feedId E2E Test', () => {
     } finally {
       //cleanup
       await Promise.all([
-        redisService.redisClient.zrem(
-          redisKeys.FEED_TREND_KEY,
-          testFeedId.toString(),
-        ),
-        redisService.redisClient.srem(`feed:${testFeedId}:ip`, testNewIp),
+        redisService.zrem(redisKeys.FEED_TREND_KEY, testFeedId.toString()),
+        redisService.srem(`feed:${testFeedId}:ip`, testNewIp),
       ]);
     }
   });
@@ -87,7 +84,7 @@ describe('POST /api/feed/:feedId E2E Test', () => {
       .post(`/api/feed/${testFeedId}`)
       .set('Cookie', `View_count_${testFeedId}=${testFeedId}`)
       .set('X-Forwarded-For', testIp);
-    const feedDailyViewCount = await redisService.redisClient.zscore(
+    const feedDailyViewCount = await redisService.zscore(
       redisKeys.FEED_TREND_KEY,
       testFeedId.toString(),
     );
@@ -102,7 +99,7 @@ describe('POST /api/feed/:feedId E2E Test', () => {
     const response = await request(app.getHttpServer())
       .post(`/api/feed/${testFeedId}`)
       .set('X-Forwarded-For', testIp);
-    const feedDailyViewCount = await redisService.redisClient.zscore(
+    const feedDailyViewCount = await redisService.zscore(
       redisKeys.FEED_TREND_KEY,
       testFeedId.toString(),
     );

--- a/server/test/feed/e2e/recent.e2e-spec.ts
+++ b/server/test/feed/e2e/recent.e2e-spec.ts
@@ -33,10 +33,10 @@ describe('GET /api/feed/recent E2E Test', () => {
     }
     const redisService = app.get(RedisService);
     const feeds = await feedRepository.save(feedList);
-    const pipeLine = redisService.redisClient.pipeline();
-    pipeLine.hset(`feed:recent:${feeds[0].id}`, feeds[0]);
-    pipeLine.hset(`feed:recent:${feeds[1].id}`, feeds[1]);
-    await pipeLine.exec();
+    await redisService.executePipeline((pipeline) => {
+      pipeline.hset(`feed:recent:${feeds[0].id}`, feeds[0]);
+      pipeline.hset(`feed:recent:${feeds[1].id}`, feeds[1]);
+    });
 
     //when
     const response = await request(app.getHttpServer()).get('/api/feed/recent');
@@ -49,7 +49,7 @@ describe('GET /api/feed/recent E2E Test', () => {
   it('최신 피드가 없다면 빈 배열을 반환한다.', async () => {
     //given
     const redisService = app.get(RedisService);
-    redisService.redisClient.flushdb();
+    redisService.flushdb();
 
     //when
     const response = await request(app.getHttpServer()).get('/api/feed/recent');

--- a/server/test/feed/e2e/trend.e2e-spec.ts
+++ b/server/test/feed/e2e/trend.e2e-spec.ts
@@ -19,7 +19,7 @@ describe('SSE /api/trend/sse E2E Test', () => {
     const redisService = app.get(RedisService);
     const [blog] = await Promise.all([
       rssAcceptRepository.save(RssAcceptFixture.createRssAcceptFixture()),
-      redisService.redisClient.rpush(redisKeys.FEED_ORIGIN_TREND_KEY, 1, 2),
+      redisService.rpush(redisKeys.FEED_ORIGIN_TREND_KEY, 1, 2),
     ]);
     const feeds: Feed[] = [];
     for (let i = 1; i <= 2; i++) {

--- a/server/test/rss/e2e/accept.e2e-spec.ts
+++ b/server/test/rss/e2e/accept.e2e-spec.ts
@@ -25,7 +25,7 @@ describe('Rss Accept E2E Test', () => {
   beforeEach(async () => {
     await Promise.all([
       rssRepository.delete({}),
-      redisService.redisClient.set('auth:sid', 'test_admin'),
+      redisService.set('auth:sid', 'test_admin'),
     ]);
   });
 

--- a/server/test/rss/e2e/history/accept.e2e-spec.ts
+++ b/server/test/rss/e2e/history/accept.e2e-spec.ts
@@ -17,7 +17,7 @@ describe('GET /api/rss/history/accept E2E Test', () => {
     }
     await Promise.all([
       rssAcceptRepository.save(rssAccepts),
-      redisService.redisClient.sadd('auth:sid', 'test1234'),
+      redisService.sadd('auth:sid', 'test1234'),
     ]);
   });
 

--- a/server/test/rss/e2e/history/reject.e2e-spec.ts
+++ b/server/test/rss/e2e/history/reject.e2e-spec.ts
@@ -17,7 +17,7 @@ describe('GET /api/rss/history/reject E2E Test', () => {
     }
     await Promise.all([
       rssRejectRepository.save(rssAccepts),
-      redisService.redisClient.sadd('auth:sid', 'test1234'),
+      redisService.sadd('auth:sid', 'test1234'),
     ]);
   });
 

--- a/server/test/rss/e2e/reject.e2e-spec.ts
+++ b/server/test/rss/e2e/reject.e2e-spec.ts
@@ -26,7 +26,7 @@ describe('Rss Reject E2E Test', () => {
   beforeEach(async () => {
     await Promise.all([
       rssRepository.delete({}),
-      redisService.redisClient.set('auth:sid', 'test_admin'),
+      redisService.set('auth:sid', 'test_admin'),
     ]);
   });
 

--- a/server/test/statistic/e2e/today.e2e-spec.ts
+++ b/server/test/statistic/e2e/today.e2e-spec.ts
@@ -18,7 +18,7 @@ describe('GET /api/statistic/today E2E Test', () => {
     const redisService = app.get(RedisService);
     const [blog] = await Promise.all([
       rssAcceptRepository.save(RssAcceptFixture.createRssAcceptFixture()),
-      redisService.redisClient.zadd(redisKeys.FEED_TREND_KEY, 5, '1', 4, '2'),
+      redisService.zadd(redisKeys.FEED_TREND_KEY, 5, '1', 4, '2'),
     ]);
     const feeds: Feed[] = [];
     for (let i = 1; i <= 2; i++) {


### PR DESCRIPTION
# 📋 작업 내용
### feed-crawler 내 `redis-access` 의존성 추가
다른 부분과 동일하게 `RedisConnection` 인스턴스도 의존성 주입방식을 통해 관리하도록 처리 하였습니다.
재사용성이 낮을것으로 생각되어, **`DatabaseConnection`과 달리 `RedisConnection`은 별도의 인터페이스를 통해 추상화 하지 않았습니다.**

### 애플리케이션 내 `RedisConnection` 동작 메서드들 구현
사용중이던 Redis 관련 메서드들을 메서드화 하였습니다. 대부분의 메서드 들은 실제 redis 객체에 접근해 사용하는 것과 큰 차이가 없도록 구현하였으나, 몇가지 특이사항 있는 부분들은 아래와 같습니다.

- **`scan()`**
`scan()` 메서드는 중복 데이터를 반환할 가능성이 있기에, **매 반복문 마다 필요한 데이터를 찾아 처리해주는 로직을 직접 작성하는 것이 옳다는 판단을 내렸습니다.**

- **`executePipeline()`**
`pipeline()` 메서드는 `ChainableCommander` 이라는 객체에 접근해 레디스 명령 함수들을 실행시키는 형태로 동작들을 수행하는데, 이때 ChainableCommander 내 함수들의 목록을 받도록 구현해야 완전한 캡슐화가 가능합니다.
하지만 이는 제겐 다소 복잡하게 느껴져 **`ChainableCommander`를 매개변수로 전달 해주고, 함수들의 모음인 콜백 함수만 받는 형태로 설계 하였습니다.**

- **그 외 실제 구현체와 차이점**
실제 구현체에서는 대부분의 key값이나 데이터들을 `string | number | Buffer` 형태로 다양한 타입을 지원합니다. 하지만 본 PR의 커스텀 구현체에서 `Buffer`는 사용할일이 없다고 판단해 별도로 지원하지 않도록 하였습니다.


