### PR TITLE
🧼 clean: 코드 일관성 향상

### DIFF
--- a/feed-crawler/src/repository/feed.repository.ts
+++ b/feed-crawler/src/repository/feed.repository.ts
@@ -34,16 +34,16 @@ export class FeedRepository {
     const promiseResults = await Promise.all(insertPromises);
 
     const insertedFeeds = promiseResults
-      .map((result: any, index) => {
-        if (result) {
-          const insertId = result.insertId;
+      .map((feed: any, index) => {
+        if (feed) {
+          const insertId = feed.insertId;
           return {
             ...resultData[index],
             id: insertId,
           };
         }
       })
-      .filter((result) => result);
+      .filter((feed) => feed);
 
     logger.info(
       `[MySQL] ${insertedFeeds.length}개의 피드 데이터가 성공적으로 데이터베이스에 삽입되었습니다.`,

--- a/server/src/admin/controller/admin.controller.ts
+++ b/server/src/admin/controller/admin.controller.ts
@@ -8,8 +8,6 @@ import {
   Req,
   Res,
   UseGuards,
-  UsePipes,
-  ValidationPipe,
 } from '@nestjs/common';
 import { Request, Response } from 'express';
 import { AdminService } from '../service/admin.service';
@@ -31,7 +29,6 @@ export class AdminController {
   @ApiLoginAdmin()
   @Post('/login')
   @HttpCode(HttpStatus.OK)
-  @UsePipes(ValidationPipe)
   async loginAdmin(
     @Body() loginAdminDto: LoginAdminRequestDto,
     @Res({ passthrough: true }) response: Response,
@@ -60,7 +57,6 @@ export class AdminController {
   @ApiCreateAdmin()
   @UseGuards(CookieAuthGuard)
   @Post('/register')
-  @UsePipes(ValidationPipe)
   async createAdmin(@Body() registerAdminDto: RegisterAdminRequestDto) {
     await this.adminService.createAdmin(registerAdminDto);
     return ApiResponse.responseWithNoContent(

--- a/server/src/admin/controller/admin.controller.ts
+++ b/server/src/admin/controller/admin.controller.ts
@@ -72,7 +72,6 @@ export class AdminController {
   @Get('/sessionId')
   @HttpCode(HttpStatus.OK)
   @UseGuards(CookieAuthGuard)
-  @UsePipes(new ValidationPipe({ transform: true }))
   async readSessionIdAdmin() {
     return ApiResponse.responseWithNoContent('정상적인 sessionId 입니다.');
   }

--- a/server/src/admin/dto/request/login-admin.dto.ts
+++ b/server/src/admin/dto/request/login-admin.dto.ts
@@ -3,7 +3,7 @@ import { ApiProperty } from '@nestjs/swagger';
 
 export class LoginAdminRequestDto {
   @ApiProperty({
-    example: 'minseokjo',
+    example: 'test',
     description: '관리자 로그인 아이디를 입력해주세요.',
   })
   @IsNotEmpty({
@@ -15,7 +15,7 @@ export class LoginAdminRequestDto {
   loginId: string;
 
   @ApiProperty({
-    example: 'heisgoat123!',
+    example: 'test1234!',
     description: '패스워드를 입력해주세요.',
   })
   @IsNotEmpty({

--- a/server/src/admin/dto/request/register-admin.dto.ts
+++ b/server/src/admin/dto/request/register-admin.dto.ts
@@ -5,7 +5,7 @@ const PASSWORD_REG = /^(?=.*[!@#$%^&*()_+])[A-Za-z0-9!@#$%^&*()_+]+$/;
 
 export class RegisterAdminRequestDto {
   @ApiProperty({
-    example: 'minseokjo',
+    example: 'test',
     description: '관리자 로그인 아이디를 입력해주세요.',
   })
   @IsString({
@@ -17,7 +17,7 @@ export class RegisterAdminRequestDto {
   loginId: string;
 
   @ApiProperty({
-    example: 'heisgoat123!',
+    example: 'test1234!',
     description:
       '패스워드를 입력해주세요. (최소 6자, 영문/숫자/특수문자로 이루어질 수 있으며 특수문자 1개 이상 포함)',
   })

--- a/server/src/feed/api-docs/searchFeedList.api-docs.ts
+++ b/server/src/feed/api-docs/searchFeedList.api-docs.ts
@@ -17,7 +17,7 @@ export function ApiSearchFeedList() {
       required: true,
       type: String,
       description: '검색어',
-      example: '데나무',
+      example: 'test',
     }),
     ApiQuery({
       name: 'type',
@@ -96,7 +96,7 @@ export function ApiSearchFeedList() {
             {
               id: 1,
               blogName: '블로그 이름',
-              title: '데나무',
+              title: 'test',
               path: 'https://test.com/1',
               createdAt: '2024-10-27T02:08:55.000Z',
             },

--- a/server/src/feed/api-docs/updateFeedViewCount.api-docs.ts
+++ b/server/src/feed/api-docs/updateFeedViewCount.api-docs.ts
@@ -3,20 +3,12 @@ import {
   ApiNotFoundResponse,
   ApiOkResponse,
   ApiOperation,
-  ApiParam,
 } from '@nestjs/swagger';
 
 export function ApiUpdateFeedViewCount() {
   return applyDecorators(
     ApiOperation({
       summary: `피드 조회수 업데이트 API`,
-    }),
-    ApiParam({
-      name: 'feedId',
-      required: true,
-      type: Number,
-      description: '클릭한 피드의 id',
-      example: 1,
     }),
     ApiOkResponse({
       description: 'Ok',

--- a/server/src/feed/controller/feed.controller.ts
+++ b/server/src/feed/controller/feed.controller.ts
@@ -88,8 +88,10 @@ export class FeedController {
     new ValidationPipe(),
   )
   async searchFeedList(@Query() searchFeedReq: SearchFeedRequestDto) {
-    const data = await this.feedService.searchFeedList(searchFeedReq);
-    return ApiResponse.responseWithData('검색 결과 조회 완료', data);
+    return ApiResponse.responseWithData(
+      '검색 결과 조회 완료',
+      await this.feedService.searchFeedList(searchFeedReq),
+    );
   }
 
   @ApiUpdateFeedViewCount()

--- a/server/src/feed/controller/feed.controller.ts
+++ b/server/src/feed/controller/feed.controller.ts
@@ -26,6 +26,7 @@ import { ApiSearchFeedList } from '../api-docs/searchFeedList.api-docs';
 import { ApiUpdateFeedViewCount } from '../api-docs/updateFeedViewCount.api-docs';
 import { ApiReadRecentFeedList } from '../api-docs/readRecentFeedList.api-docs';
 import { FeedTrendResponseDto } from '../dto/response/feed-pagination.dto';
+import { FeedViewUpdateRequestDto } from '../dto/request/feed-update.dto';
 
 @ApiTags('Feed')
 @Controller('feed')
@@ -99,11 +100,15 @@ export class FeedController {
   @HttpCode(HttpStatus.OK)
   @UsePipes(new ValidationPipe({ transform: true }))
   async updateFeedViewCount(
-    @Param('feedId') feedId: number,
+    @Param() params: FeedViewUpdateRequestDto,
     @Req() request: Request,
     @Res({ passthrough: true }) response: Response,
   ) {
-    await this.feedService.updateFeedViewCount(feedId, request, response);
+    await this.feedService.updateFeedViewCount(
+      params.feedId,
+      request,
+      response,
+    );
     return ApiResponse.responseWithNoContent(
       '요청이 성공적으로 처리되었습니다.',
     );

--- a/server/src/feed/controller/feed.controller.ts
+++ b/server/src/feed/controller/feed.controller.ts
@@ -11,8 +11,6 @@ import {
   Req,
   Res,
   Sse,
-  UsePipes,
-  ValidationPipe,
 } from '@nestjs/common';
 import { FeedService } from '../service/feed.service';
 import { FeedPaginationRequestDto } from '../dto/request/feed-pagination.dto';
@@ -39,7 +37,6 @@ export class FeedController {
   @ApiReadFeedPagination()
   @Get('')
   @HttpCode(HttpStatus.OK)
-  @UsePipes(new ValidationPipe({ transform: true }))
   async readFeedPagination(@Query() queryFeedDto: FeedPaginationRequestDto) {
     return ApiResponse.responseWithData(
       '피드 조회 완료',
@@ -78,7 +75,6 @@ export class FeedController {
   @ApiSearchFeedList()
   @Get('search')
   @HttpCode(HttpStatus.OK)
-  @UsePipes(new ValidationPipe({ transform: true }))
   async searchFeedList(@Query() searchFeedReq: SearchFeedRequestDto) {
     return ApiResponse.responseWithData(
       '검색 결과 조회 완료',
@@ -89,7 +85,6 @@ export class FeedController {
   @ApiUpdateFeedViewCount()
   @Post('/:feedId')
   @HttpCode(HttpStatus.OK)
-  @UsePipes(new ValidationPipe({ transform: true }))
   async updateFeedViewCount(
     @Param() params: FeedViewUpdateRequestDto,
     @Req() request: Request,

--- a/server/src/feed/controller/feed.controller.ts
+++ b/server/src/feed/controller/feed.controller.ts
@@ -39,11 +39,7 @@ export class FeedController {
   @ApiReadFeedPagination()
   @Get('')
   @HttpCode(HttpStatus.OK)
-  @UsePipes(
-    new ValidationPipe({
-      transform: true,
-    }),
-  )
+  @UsePipes(new ValidationPipe({ transform: true }))
   async readFeedPagination(@Query() queryFeedDto: FeedPaginationRequestDto) {
     return ApiResponse.responseWithData(
       '피드 조회 완료',
@@ -82,12 +78,7 @@ export class FeedController {
   @ApiSearchFeedList()
   @Get('search')
   @HttpCode(HttpStatus.OK)
-  @UsePipes(
-    new ValidationPipe({
-      transform: true,
-    }),
-    new ValidationPipe(),
-  )
+  @UsePipes(new ValidationPipe({ transform: true }))
   async searchFeedList(@Query() searchFeedReq: SearchFeedRequestDto) {
     return ApiResponse.responseWithData(
       '검색 결과 조회 완료',

--- a/server/src/feed/dto/request/feed-update.dto.ts
+++ b/server/src/feed/dto/request/feed-update.dto.ts
@@ -4,7 +4,7 @@ import { IsInt } from 'class-validator';
 
 export class FeedViewUpdateRequestDto {
   @ApiProperty({
-    example: 10,
+    example: 1,
     description: '조회할 ID 입력',
   })
   @IsInt({

--- a/server/src/feed/dto/request/feed-update.dto.ts
+++ b/server/src/feed/dto/request/feed-update.dto.ts
@@ -1,0 +1,16 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { Type } from 'class-transformer';
+import { IsInt } from 'class-validator';
+
+export class FeedViewUpdateRequestDto {
+  @ApiProperty({
+    example: 10,
+    description: '조회할 ID 입력',
+    name: '게시글 ID',
+  })
+  @IsInt({
+    message: '정수를 입력해주세요.',
+  })
+  @Type(() => Number)
+  feedId: number;
+}

--- a/server/src/feed/dto/request/feed-update.dto.ts
+++ b/server/src/feed/dto/request/feed-update.dto.ts
@@ -6,7 +6,6 @@ export class FeedViewUpdateRequestDto {
   @ApiProperty({
     example: 10,
     description: '조회할 ID 입력',
-    name: '게시글 ID',
   })
   @IsInt({
     message: '정수를 입력해주세요.',

--- a/server/src/feed/dto/response/feed-pagination.dto.ts
+++ b/server/src/feed/dto/response/feed-pagination.dto.ts
@@ -39,8 +39,12 @@ export class FeedPaginationResponseDto {
     private hasMore: boolean,
   ) {}
 
-  static toResponseDto(result: FeedResult[], lastId: number, hasMore: boolean) {
-    return new FeedPaginationResponseDto(result, lastId, hasMore);
+  static toResponseDto(
+    feedPagination: FeedResult[],
+    lastId: number,
+    hasMore: boolean,
+  ) {
+    return new FeedPaginationResponseDto(feedPagination, lastId, hasMore);
   }
 }
 

--- a/server/src/main.ts
+++ b/server/src/main.ts
@@ -6,6 +6,7 @@ import * as cookieParser from 'cookie-parser';
 import { InternalExceptionsFilter } from './common/filters/internal-exceptions.filter';
 import { LoggingInterceptor } from './common/logger/logger.interceptor';
 import { WinstonLoggerService } from './common/logger/logger.service';
+import { ValidationPipe } from '@nestjs/common';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
@@ -17,6 +18,7 @@ async function bootstrap() {
     new InternalExceptionsFilter(logger),
     new HttpExceptionsFilter(),
   );
+  app.useGlobalPipes(new ValidationPipe({ transform: true }));
   app.enableCors({
     origin: [
       'http://localhost:5173',

--- a/server/src/rss/controller/rss.controller.ts
+++ b/server/src/rss/controller/rss.controller.ts
@@ -4,7 +4,6 @@ import {
   Get,
   HttpCode,
   Param,
-  ParseIntPipe,
   Post,
   UsePipes,
   ValidationPipe,
@@ -53,8 +52,7 @@ export class RssController {
   @Post('accept/:id')
   @HttpCode(201)
   async acceptRss(@Param() params: RssManagementRequestDto) {
-    const { id } = params;
-    await this.rssService.acceptRss(id);
+    await this.rssService.acceptRss(params.id);
     return ApiResponse.responseWithNoContent('승인이 완료되었습니다.');
   }
 
@@ -67,8 +65,7 @@ export class RssController {
     @Body() body: RejectRssRequestDto,
     @Param() params: RssManagementRequestDto,
   ) {
-    const { id } = params;
-    await this.rssService.rejectRss(id, body.description);
+    await this.rssService.rejectRss(params.id, body.description);
     return ApiResponse.responseWithNoContent('거절이 완료되었습니다.');
   }
 

--- a/server/src/rss/controller/rss.controller.ts
+++ b/server/src/rss/controller/rss.controller.ts
@@ -5,8 +5,6 @@ import {
   HttpCode,
   Param,
   Post,
-  UsePipes,
-  ValidationPipe,
   UseGuards,
 } from '@nestjs/common';
 import { CookieAuthGuard } from '../../common/guard/auth.guard';
@@ -30,7 +28,6 @@ export class RssController {
 
   @ApiCreateRss()
   @Post()
-  @UsePipes(ValidationPipe)
   async createRss(@Body() rssRegisterDto: RssRegisterRequestDto) {
     await this.rssService.createRss(rssRegisterDto);
     return ApiResponse.responseWithNoContent('신청이 완료되었습니다.');
@@ -48,7 +45,6 @@ export class RssController {
 
   @ApiAcceptRss()
   @UseGuards(CookieAuthGuard)
-  @UsePipes(new ValidationPipe({ transform: true }))
   @Post('accept/:id')
   @HttpCode(201)
   async acceptRss(@Param() params: RssManagementRequestDto) {
@@ -57,7 +53,6 @@ export class RssController {
   }
 
   @ApiRejectRss()
-  @UsePipes(ValidationPipe)
   @UseGuards(CookieAuthGuard)
   @Post('reject/:id')
   @HttpCode(201)

--- a/server/src/rss/dto/request/rss-register.dto.ts
+++ b/server/src/rss/dto/request/rss-register.dto.ts
@@ -16,7 +16,7 @@ export class RssRegisterRequestDto {
   blog: string;
 
   @ApiProperty({
-    example: 'J235_조민석',
+    example: 'test',
     description: '실명을 입력해주세요.',
   })
   @Length(2, 50, { message: '이름 길이가 올바르지 않습니다.' })
@@ -29,7 +29,7 @@ export class RssRegisterRequestDto {
   name: string;
 
   @ApiProperty({
-    example: 'seok3765@naver.com',
+    example: 'test@test.com',
     description: '이메일을 입력해주세요.',
   })
   @IsEmail(
@@ -44,7 +44,7 @@ export class RssRegisterRequestDto {
   email: string;
 
   @ApiProperty({
-    example: 'https://v2.velog.io/rss/@seok3765',
+    example: 'https://test.com/rss',
     description: 'RSS 주소를 입력해주세요.',
   })
   @IsUrl(

--- a/server/src/statistic/controller/statistic.controller.ts
+++ b/server/src/statistic/controller/statistic.controller.ts
@@ -25,8 +25,10 @@ export class StatisticController {
     }),
   )
   async readTodayStatistic(@Query() queryObj: StatisticRequestDto) {
-    const data = await this.statisticService.readTodayStatistic(queryObj.limit);
-    return ApiResponse.responseWithData('금일 조회수 통계 조회 완료', data);
+    return ApiResponse.responseWithData(
+      '금일 조회수 통계 조회 완료',
+      await this.statisticService.readTodayStatistic(queryObj.limit),
+    );
   }
 
   @ApiStatistic('all')
@@ -37,14 +39,18 @@ export class StatisticController {
     }),
   )
   async readAllStatistic(@Query() queryObj: StatisticRequestDto) {
-    const data = await this.statisticService.readAllStatistic(queryObj.limit);
-    return ApiResponse.responseWithData('전체 조회수 통계 조회 완료', data);
+    return ApiResponse.responseWithData(
+      '전체 조회수 통계 조회 완료',
+      await this.statisticService.readAllStatistic(queryObj.limit),
+    );
   }
 
   @ApiReadPlatformStatistic()
   @Get('platform')
   async readPlatformStatistic() {
-    const data = await this.statisticService.readPlatformStatistic();
-    return ApiResponse.responseWithData('블로그 플랫폼 통계 조회 완료', data);
+    return ApiResponse.responseWithData(
+      '블로그 플랫폼 통계 조회 완료',
+      await this.statisticService.readPlatformStatistic(),
+    );
   }
 }

--- a/server/src/statistic/controller/statistic.controller.ts
+++ b/server/src/statistic/controller/statistic.controller.ts
@@ -1,10 +1,4 @@
-import {
-  Controller,
-  Get,
-  Query,
-  UsePipes,
-  ValidationPipe,
-} from '@nestjs/common';
+import { Controller, Get, Query } from '@nestjs/common';
 import { StatisticService } from '../service/statistic.service';
 import { ApiResponse } from '../../common/response/common.response';
 import { ApiTags } from '@nestjs/swagger';
@@ -19,7 +13,6 @@ export class StatisticController {
 
   @ApiStatistic('today')
   @Get('today')
-  @UsePipes(new ValidationPipe({ transform: true }))
   async readTodayStatistic(@Query() queryObj: StatisticRequestDto) {
     return ApiResponse.responseWithData(
       '금일 조회수 통계 조회 완료',
@@ -29,7 +22,6 @@ export class StatisticController {
 
   @ApiStatistic('all')
   @Get('all')
-  @UsePipes(new ValidationPipe({ transform: true }))
   async readAllStatistic(@Query() queryObj: StatisticRequestDto) {
     return ApiResponse.responseWithData(
       '전체 조회수 통계 조회 완료',

--- a/server/src/statistic/controller/statistic.controller.ts
+++ b/server/src/statistic/controller/statistic.controller.ts
@@ -19,11 +19,7 @@ export class StatisticController {
 
   @ApiStatistic('today')
   @Get('today')
-  @UsePipes(
-    new ValidationPipe({
-      transform: true,
-    }),
-  )
+  @UsePipes(new ValidationPipe({ transform: true }))
   async readTodayStatistic(@Query() queryObj: StatisticRequestDto) {
     return ApiResponse.responseWithData(
       '금일 조회수 통계 조회 완료',
@@ -33,11 +29,7 @@ export class StatisticController {
 
   @ApiStatistic('all')
   @Get('all')
-  @UsePipes(
-    new ValidationPipe({
-      transform: true,
-    }),
-  )
+  @UsePipes(new ValidationPipe({ transform: true }))
   async readAllStatistic(@Query() queryObj: StatisticRequestDto) {
     return ApiResponse.responseWithData(
       '전체 조회수 통계 조회 완료',

--- a/server/src/statistic/service/statistic.service.ts
+++ b/server/src/statistic/service/statistic.service.ts
@@ -23,7 +23,7 @@ export class StatisticService {
       limit - 1,
       'WITHSCORES',
     );
-    const result: Partial<Feed>[] = [];
+    const todayFeedViews: Partial<Feed>[] = [];
 
     for (let i = 0; i < ranking.length; i += 2) {
       const feedId = parseInt(ranking[i]);
@@ -34,14 +34,14 @@ export class StatisticService {
         relations: ['blog'],
       });
 
-      result.push({
+      todayFeedViews.push({
         id: feedData.id,
         title: feedData.title,
         viewCount: score,
       });
     }
 
-    return StatisticTodayResponseDto.toResponseDtoArray(result);
+    return StatisticTodayResponseDto.toResponseDtoArray(todayFeedViews);
   }
 
   async readAllStatistic(limit: number) {

--- a/server/test/feed/e2e/trend.e2e-spec.ts
+++ b/server/test/feed/e2e/trend.e2e-spec.ts
@@ -41,8 +41,8 @@ describe('SSE /api/trend/sse E2E Test', () => {
       es.onmessage = (event) => {
         try {
           const response = JSON.parse(event.data);
-          const data = response.data;
-          const idList = data.map((item) => item.id);
+          const feedList = response.data;
+          const idList = feedList.map((feed) => feed.id);
           es.close();
           resolve(idList);
         } catch (error) {
@@ -77,8 +77,8 @@ describe('SSE /api/trend/sse E2E Test', () => {
       es.onmessage = (event) => {
         try {
           const response = JSON.parse(event.data);
-          const data = response.data;
-          const idList = data.map((item) => item.id);
+          const feedList = response.data;
+          const idList = feedList.map((feed) => feed.id);
           es.close();
           resolve(idList);
         } catch (error) {

--- a/server/test/jest.setup.ts
+++ b/server/test/jest.setup.ts
@@ -1,5 +1,5 @@
-import { INestApplication } from '@nestjs/common';
-import { Test, TestingModule } from '@nestjs/testing';
+import { INestApplication, ValidationPipe } from '@nestjs/common';
+import { Test } from '@nestjs/testing';
 import { AppModule } from '../src/app.module';
 import { WinstonLoggerService } from '../src/common/logger/logger.service';
 import { InternalExceptionsFilter } from '../src/common/filters/internal-exceptions.filter';
@@ -20,6 +20,7 @@ beforeAll(async () => {
     new InternalExceptionsFilter(logger),
     new HttpExceptionsFilter(),
   );
+  app.useGlobalPipes(new ValidationPipe({ transform: true }));
   await app.init();
   global.testApp = app;
 });

--- a/server/test/rss/e2e/history/accept.e2e-spec.ts
+++ b/server/test/rss/e2e/history/accept.e2e-spec.ts
@@ -43,6 +43,8 @@ describe('GET /api/rss/history/accept E2E Test', () => {
 
     // then
     expect(response.status).toBe(200);
-    expect(response.body.data.map((item) => item.id)).toStrictEqual([2, 1]);
+    expect(response.body.data.map((acceptRss) => acceptRss.id)).toStrictEqual([
+      2, 1,
+    ]);
   });
 });

--- a/server/test/rss/e2e/history/reject.e2e-spec.ts
+++ b/server/test/rss/e2e/history/reject.e2e-spec.ts
@@ -43,6 +43,8 @@ describe('GET /api/rss/history/reject E2E Test', () => {
 
     // then
     expect(response.status).toBe(200);
-    expect(response.body.data.map((item) => item.id)).toStrictEqual([2, 1]);
+    expect(response.body.data.map((rejectRss) => rejectRss.id)).toStrictEqual([
+      2, 1,
+    ]);
   });
 });

--- a/server/test/statistic/e2e/all.e2e-spec.ts
+++ b/server/test/statistic/e2e/all.e2e-spec.ts
@@ -31,7 +31,7 @@ describe('GET /api/statistic/all E2E Test', () => {
 
     // then
     expect(response.status).toBe(200);
-    expect(response.body.data.map((item) => item.id)).toStrictEqual([2, 1]);
+    expect(response.body.data.map((feed) => feed.id)).toStrictEqual([2, 1]);
   });
   it('양수를 입력하면 제한된 개수의 통계 결과를 응답한다.', async () => {
     // when
@@ -41,6 +41,6 @@ describe('GET /api/statistic/all E2E Test', () => {
 
     // then
     expect(response.status).toBe(200);
-    expect(response.body.data.map((item) => item.id)).toStrictEqual([2]);
+    expect(response.body.data.map((feed) => feed.id)).toStrictEqual([2]);
   });
 });

--- a/server/test/statistic/e2e/today.e2e-spec.ts
+++ b/server/test/statistic/e2e/today.e2e-spec.ts
@@ -34,7 +34,7 @@ describe('GET /api/statistic/today E2E Test', () => {
 
     // then
     expect(response.status).toBe(200);
-    expect(response.body.data.map((item) => item.id)).toStrictEqual([1, 2]);
+    expect(response.body.data.map((feed) => feed.id)).toStrictEqual([1, 2]);
   });
   it('양수를 입력하면 제한된 개수의 통계 결과를 응답한다.', async () => {
     // when
@@ -44,6 +44,6 @@ describe('GET /api/statistic/today E2E Test', () => {
 
     // then
     expect(response.status).toBe(200);
-    expect(response.body.data.map((item) => item.id)).toStrictEqual([1]);
+    expect(response.body.data.map((feed) => feed.id)).toStrictEqual([1]);
   });
 });


### PR DESCRIPTION
# 🔨 테스크

### Redis Scan 반환을 정수로 바꾸면 안 되나?

-   Redis에 어느 정도의 데이터가 저장되어있는 지 애플리케이션 단에서 미리 파악할 수 없다.
- JS의 최대 숫자 범위를 벗어나버리면 서비스 예외가 발생한다.
- JS의 최대 숫자 범위 9007199254740991 만큼 개수 범위가 크지는 않겠지만 시스템 안정성을 위해 문자열로 반환하도록 처리 

### 다음 작업 수행 목록 (PR룰에 따라 분리)
1. Repository 함수 재사용하게 변경
2. Swagger 처리 부분 변경
    - Swagger Request Example `api-docs.ts` -> `DTO`로 변경
        - 작업 사유: 현재 새로운 API 생성시 api-docs.ts에 수동으로 API Request DTO의 속성들을 등록하는 몇몇 부분들이 있음. Request DTO를 생성할 때, ApiProperty를 사용해서 자동으로 연동되도록 하는 게 편할듯 함
    - Swagger Response Example `DTO`로 변경 하능 하다면 변경
        - 작업 사유: 위와 동일

# 작업 사유
- 코드는 여러 명이 적었다 한들 하나의 프로젝트 내부라면 코드 형식이 모두 동일해야 한다고 판단했다.
- 추상적으로 작성되어 있는 코드들이 많아 다시 코드를 읽을 때 이해 안 되는 부분이 상당히 많았다.
- 눈에 거슬리는 코드도 너무 많았기에 작업을 수행했다.
- 정규 프로젝트 기간에는 마감 일자로 인해 촉박해져 막 작업한 부분이 꽤 많았다.

# 📋 작업 내용
- 파라미터 DTO 적용 하여 값 검증하게 변경
    - 특정 코드는 파라미터를 직접 추출하는 방식이라 값 검증이 안 되는 문제가 있었음. 코드 통일성을 위해 DTO 추가
    ```typescript
    @Params('feedId') params: Params
   ```
   변경
    ```typescript
    @Params('feedId') params: FeedPaginationRequestDto
   ```
-  Validation 코드 정리, 제거
    - 필요없는 Validation 발견하여 정리함, 라인도 정리
- Controller 별도 data 변수 없애서 코드 통일
    - 몇몇 Controller 코드에서 일관성이 맞지 않음을 확인
    ```typescript
    const data = 서비스 함수();
    return ApiResponse.responseWithData('메세지',data);
    ```
   변경
     ```typescript
    return ApiResponse.responseWithData('메세지',서비스 함수());
    ```
- 파라미터 별도 변수 제거
   ```typescript
   const { id } = params
  서비스 함수(id);
   ```
   불필요하게 id 변수를 생성하는 구문 제거
   ```typescript
   서비스 함수(params.id);
   ```
- Request Example 더미 데이터로 변경
    더미 데이터(ex. test)가 아닌 임시 데이터(ex. seok3765)가 들어가 있는  부분 변경

- 변수 이름 result, item, data 처럼 추상적인 부분 구체화
    map, filter 같이 고차 함수에서 result, item, data와 같이 추상적인 변수명으로 가독성이 불편했던 부분 구체화를 통해 개선

- Validation Pipe Global로 변경
    추후 컨트롤러에 함수를 추가할 때마다 UsePipe로 Validation을 수행하도록 적어야 한다.
   코드 중복이 발생한다고 생각했고, 번거로움이 느껴졌다. 간결하게 표현이 가능할 것 같았다.
   어짜피 모든 Request를 DTO로 사용하자고 얘기가 나왔기 때문에 Global Pipe로 처리해도 문제없을 것 같다고 생각했다.
