### PR TITLE
♻️ refactor: Admin 도메인 Repository 변수 대입 형식 -> 엔티티 DTO 변환 형식으로 변경, 테스트 코드 최적화

### DIFF
--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -46,6 +46,7 @@
         "@nestjs/cli": "^10.0.0",
         "@nestjs/schematics": "^10.0.0",
         "@nestjs/testing": "^10.0.0",
+        "@types/bcrypt": "^5.0.2",
         "@types/cookie-parser": "^1.4.7",
         "@types/eventsource": "^1.1.15",
         "@types/express": "^5.0.0",
@@ -2587,6 +2588,16 @@
       "license": "MIT",
       "dependencies": {
         "@babel/types": "^7.20.7"
+      }
+    },
+    "node_modules/@types/bcrypt": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@types/bcrypt/-/bcrypt-5.0.2.tgz",
+      "integrity": "sha512-6atioO8Y75fNcbmj0G7UjI9lXN2pQ/IGJ2FWT4a/btd0Lk9lQalHLKhkgKVZ3r+spnmWUKfbMi1GEe9wyHQfNQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/@types/body-parser": {

--- a/server/package.json
+++ b/server/package.json
@@ -58,6 +58,7 @@
     "@nestjs/cli": "^10.0.0",
     "@nestjs/schematics": "^10.0.0",
     "@nestjs/testing": "^10.0.0",
+    "@types/bcrypt": "^5.0.2",
     "@types/cookie-parser": "^1.4.7",
     "@types/eventsource": "^1.1.15",
     "@types/express": "^5.0.0",

--- a/server/src/admin/controller/admin.controller.ts
+++ b/server/src/admin/controller/admin.controller.ts
@@ -30,11 +30,11 @@ export class AdminController {
   @Post('/login')
   @HttpCode(HttpStatus.OK)
   async loginAdmin(
-    @Body() loginAdminDto: LoginAdminRequestDto,
+    @Body() loginAdminBodyDto: LoginAdminRequestDto,
     @Res({ passthrough: true }) response: Response,
     @Req() request: Request,
   ) {
-    await this.adminService.loginAdmin(loginAdminDto, response, request);
+    await this.adminService.loginAdmin(loginAdminBodyDto, response, request);
     return ApiResponse.responseWithNoContent(
       '로그인이 성공적으로 처리되었습니다.',
     );
@@ -57,8 +57,8 @@ export class AdminController {
   @ApiCreateAdmin()
   @UseGuards(CookieAuthGuard)
   @Post('/register')
-  async createAdmin(@Body() registerAdminDto: RegisterAdminRequestDto) {
-    await this.adminService.createAdmin(registerAdminDto);
+  async createAdmin(@Body() registerAdminBodyDto: RegisterAdminRequestDto) {
+    await this.adminService.createAdmin(registerAdminBodyDto);
     return ApiResponse.responseWithNoContent(
       '성공적으로 관리자 계정이 생성되었습니다.',
     );

--- a/server/src/admin/dto/request/register-admin.dto.ts
+++ b/server/src/admin/dto/request/register-admin.dto.ts
@@ -36,8 +36,7 @@ export class RegisterAdminRequestDto {
 
   toEntity() {
     const admin = new Admin();
-    admin.loginId = this.loginId;
-    admin.password = this.password;
+    Object.assign(admin, this);
     return admin;
   }
 }

--- a/server/src/admin/dto/request/register-admin.dto.ts
+++ b/server/src/admin/dto/request/register-admin.dto.ts
@@ -1,5 +1,6 @@
 import { IsString, Length, Matches } from 'class-validator';
 import { ApiProperty } from '@nestjs/swagger';
+import { Admin } from '../../entity/admin.entity';
 
 const PASSWORD_REG = /^(?=.*[!@#$%^&*()_+])[A-Za-z0-9!@#$%^&*()_+]+$/;
 
@@ -32,4 +33,11 @@ export class RegisterAdminRequestDto {
     message: '패스워드의 길이는 6자 이상, 60자 이하로 작성해주세요.',
   })
   password: string;
+
+  toEntity() {
+    const admin = new Admin();
+    admin.loginId = this.loginId;
+    admin.password = this.password;
+    return admin;
+  }
 }

--- a/server/src/admin/repository/admin.repository.ts
+++ b/server/src/admin/repository/admin.repository.ts
@@ -1,21 +1,10 @@
 import { Injectable } from '@nestjs/common';
 import { DataSource, Repository } from 'typeorm';
 import { Admin } from '../entity/admin.entity';
-import { RegisterAdminRequestDto } from '../dto/request/register-admin.dto';
 
 @Injectable()
 export class AdminRepository extends Repository<Admin> {
   constructor(private dataSource: DataSource) {
     super(Admin, dataSource.createEntityManager());
-  }
-
-  async createAdmin(registerAdminDto: RegisterAdminRequestDto) {
-    const { loginId, password } = registerAdminDto;
-    const admin = this.create({
-      loginId,
-      password,
-    });
-    await this.save(admin);
-    return admin;
   }
 }

--- a/server/src/admin/service/admin.service.ts
+++ b/server/src/admin/service/admin.service.ts
@@ -23,12 +23,12 @@ export class AdminService {
   ) {}
 
   async loginAdmin(
-    loginAdminDto: LoginAdminRequestDto,
+    loginAdminBodyDto: LoginAdminRequestDto,
     response: Response,
     request: Request,
   ) {
     const cookie = request.cookies['sessionId'];
-    const { loginId, password } = loginAdminDto;
+    const { loginId, password } = loginAdminBodyDto;
 
     const admin = await this.adminRepository.findOne({
       where: { loginId },
@@ -90,8 +90,8 @@ export class AdminService {
     response.clearCookie('sessionId');
   }
 
-  async createAdmin(registerAdminDto: RegisterAdminRequestDto) {
-    let { loginId, password } = registerAdminDto;
+  async createAdmin(registerAdminBodyDto: RegisterAdminRequestDto) {
+    let { loginId, password } = registerAdminBodyDto;
 
     const existingAdmin = await this.adminRepository.findOne({
       where: { loginId },

--- a/server/src/admin/service/admin.service.ts
+++ b/server/src/admin/service/admin.service.ts
@@ -91,10 +91,8 @@ export class AdminService {
   }
 
   async createAdmin(registerAdminBodyDto: RegisterAdminRequestDto) {
-    let { loginId, password } = registerAdminBodyDto;
-
     const existingAdmin = await this.adminRepository.findOne({
-      where: { loginId },
+      where: { loginId: registerAdminBodyDto.loginId },
     });
 
     if (existingAdmin) {
@@ -102,8 +100,11 @@ export class AdminService {
     }
 
     const saltRounds = 10;
-    password = await bcrypt.hash(password, saltRounds);
+    registerAdminBodyDto.password = await bcrypt.hash(
+      registerAdminBodyDto.password,
+      saltRounds,
+    );
 
-    await this.adminRepository.createAdmin({ loginId, password });
+    await this.adminRepository.save(registerAdminBodyDto.toEntity());
   }
 }

--- a/server/src/feed/controller/feed.controller.ts
+++ b/server/src/feed/controller/feed.controller.ts
@@ -37,10 +37,12 @@ export class FeedController {
   @ApiReadFeedPagination()
   @Get('')
   @HttpCode(HttpStatus.OK)
-  async readFeedPagination(@Query() queryFeedDto: FeedPaginationRequestDto) {
+  async readFeedPagination(
+    @Query() feedPaginationQueryDto: FeedPaginationRequestDto,
+  ) {
     return ApiResponse.responseWithData(
       '피드 조회 완료',
-      await this.feedService.readFeedPagination(queryFeedDto),
+      await this.feedService.readFeedPagination(feedPaginationQueryDto),
     );
   }
 
@@ -75,10 +77,10 @@ export class FeedController {
   @ApiSearchFeedList()
   @Get('search')
   @HttpCode(HttpStatus.OK)
-  async searchFeedList(@Query() searchFeedReq: SearchFeedRequestDto) {
+  async searchFeedList(@Query() searchFeedQueryDto: SearchFeedRequestDto) {
     return ApiResponse.responseWithData(
       '검색 결과 조회 완료',
-      await this.feedService.searchFeedList(searchFeedReq),
+      await this.feedService.searchFeedList(searchFeedQueryDto),
     );
   }
 
@@ -86,12 +88,12 @@ export class FeedController {
   @Post('/:feedId')
   @HttpCode(HttpStatus.OK)
   async updateFeedViewCount(
-    @Param() params: FeedViewUpdateRequestDto,
+    @Param() viewUpdateParamDto: FeedViewUpdateRequestDto,
     @Req() request: Request,
     @Res({ passthrough: true }) response: Response,
   ) {
     await this.feedService.updateFeedViewCount(
-      params.feedId,
+      viewUpdateParamDto,
       request,
       response,
     );

--- a/server/src/rss/controller/rss.controller.ts
+++ b/server/src/rss/controller/rss.controller.ts
@@ -28,8 +28,8 @@ export class RssController {
 
   @ApiCreateRss()
   @Post()
-  async createRss(@Body() rssRegisterDto: RssRegisterRequestDto) {
-    await this.rssService.createRss(rssRegisterDto);
+  async createRss(@Body() rssRegisterBodyDto: RssRegisterRequestDto) {
+    await this.rssService.createRss(rssRegisterBodyDto);
     return ApiResponse.responseWithNoContent('신청이 완료되었습니다.');
   }
 
@@ -47,8 +47,8 @@ export class RssController {
   @UseGuards(CookieAuthGuard)
   @Post('accept/:id')
   @HttpCode(201)
-  async acceptRss(@Param() params: RssManagementRequestDto) {
-    await this.rssService.acceptRss(params.id);
+  async acceptRss(@Param() rssAcceptParamDto: RssManagementRequestDto) {
+    await this.rssService.acceptRss(rssAcceptParamDto);
     return ApiResponse.responseWithNoContent('승인이 완료되었습니다.');
   }
 
@@ -57,10 +57,10 @@ export class RssController {
   @Post('reject/:id')
   @HttpCode(201)
   async rejectRss(
-    @Body() body: RejectRssRequestDto,
-    @Param() params: RssManagementRequestDto,
+    @Body() rssRejectBodyDto: RejectRssRequestDto,
+    @Param() rssRejectParamDto: RssManagementRequestDto,
   ) {
-    await this.rssService.rejectRss(params.id, body.description);
+    await this.rssService.rejectRss(rssRejectParamDto, rssRejectBodyDto);
     return ApiResponse.responseWithNoContent('거절이 완료되었습니다.');
   }
 

--- a/server/src/rss/service/rss.service.ts
+++ b/server/src/rss/service/rss.service.ts
@@ -16,6 +16,8 @@ import { FeedCrawlerService } from './feed-crawler.service';
 import { RssReadResponseDto } from '../dto/response/rss-all.dto';
 import { RssAcceptHistoryResponseDto } from '../dto/response/rss-accept-history.dto';
 import { RssRejectHistoryResponseDto } from '../dto/response/rss-reject-history.dto';
+import { RssManagementRequestDto } from '../dto/request/rss-management.dto';
+import { RejectRssRequestDto } from '../dto/request/rss-reject.dto';
 
 @Injectable()
 export class RssService {
@@ -28,16 +30,16 @@ export class RssService {
     private readonly feedCrawlerService: FeedCrawlerService,
   ) {}
 
-  async createRss(rssRegisterDto: RssRegisterRequestDto) {
+  async createRss(rssRegisterBodyDto: RssRegisterRequestDto) {
     const [alreadyURLRss, alreadyURLBlog] = await Promise.all([
       this.rssRepository.findOne({
         where: {
-          rssUrl: rssRegisterDto.rssUrl,
+          rssUrl: rssRegisterBodyDto.rssUrl,
         },
       }),
       this.rssAcceptRepository.findOne({
         where: {
-          rssUrl: rssRegisterDto.rssUrl,
+          rssUrl: rssRegisterBodyDto.rssUrl,
         },
       }),
     ]);
@@ -50,7 +52,7 @@ export class RssService {
       );
     }
 
-    await this.rssRepository.insertNewRss(rssRegisterDto);
+    await this.rssRepository.insertNewRss(rssRegisterBodyDto);
   }
 
   async readAllRss() {
@@ -58,9 +60,10 @@ export class RssService {
     return RssReadResponseDto.toResponseDtoArray(rssList);
   }
 
-  async acceptRss(id: number) {
+  async acceptRss(rssAcceptParamDto: RssManagementRequestDto) {
+    const rssId = rssAcceptParamDto.id;
     const rss = await this.rssRepository.findOne({
-      where: { id },
+      where: { id: rssId },
     });
 
     if (!rss) {
@@ -73,7 +76,7 @@ export class RssService {
       async (manager) => {
         const [rssAccept] = await Promise.all([
           manager.save(RssAccept.fromRss(rss, blogPlatform)),
-          manager.delete(Rss, id),
+          manager.delete(Rss, rssId),
         ]);
         const feeds = await this.feedCrawlerService.loadRssFeeds(
           rssAccept.rssUrl,
@@ -85,9 +88,13 @@ export class RssService {
     this.emailService.sendMail(rssAccept, true);
   }
 
-  async rejectRss(id: number, description: string) {
+  async rejectRss(
+    rssRejectParamDto: RssManagementRequestDto,
+    rssRejectBodyDto: RejectRssRequestDto,
+  ) {
+    const rssId = rssRejectParamDto.id;
     const rss = await this.rssRepository.findOne({
-      where: { id },
+      where: { id: rssId },
     });
 
     if (!rss) {
@@ -99,12 +106,12 @@ export class RssService {
         manager.remove(rss),
         manager.save(RssReject, {
           ...rss,
-          description,
+          description: rssRejectBodyDto.description,
         }),
       ]);
       return rejectRss;
     });
-    this.emailService.sendMail(rejectRss, false, description);
+    this.emailService.sendMail(rejectRss, false, rssRejectBodyDto.description);
   }
 
   async readAcceptHistory() {

--- a/server/src/statistic/controller/statistic.controller.ts
+++ b/server/src/statistic/controller/statistic.controller.ts
@@ -13,19 +13,19 @@ export class StatisticController {
 
   @ApiStatistic('today')
   @Get('today')
-  async readTodayStatistic(@Query() queryObj: StatisticRequestDto) {
+  async readTodayStatistic(@Query() statisticQueryDto: StatisticRequestDto) {
     return ApiResponse.responseWithData(
       '금일 조회수 통계 조회 완료',
-      await this.statisticService.readTodayStatistic(queryObj.limit),
+      await this.statisticService.readTodayStatistic(statisticQueryDto),
     );
   }
 
   @ApiStatistic('all')
   @Get('all')
-  async readAllStatistic(@Query() queryObj: StatisticRequestDto) {
+  async readAllStatistic(@Query() statisticQueryDto: StatisticRequestDto) {
     return ApiResponse.responseWithData(
       '전체 조회수 통계 조회 완료',
-      await this.statisticService.readAllStatistic(queryObj.limit),
+      await this.statisticService.readAllStatistic(statisticQueryDto),
     );
   }
 

--- a/server/src/statistic/service/statistic.service.ts
+++ b/server/src/statistic/service/statistic.service.ts
@@ -7,6 +7,7 @@ import { redisKeys } from '../../common/redis/redis.constant';
 import { StatisticPlatformResponseDto } from '../dto/response/platform.dto';
 import { StatisticTodayResponseDto } from '../dto/response/today.dto';
 import { Feed } from '../../feed/entity/feed.entity';
+import { StatisticRequestDto } from '../dto/request/statistic-query.dto';
 
 @Injectable()
 export class StatisticService {
@@ -16,11 +17,11 @@ export class StatisticService {
     private readonly rssAcceptRepository: RssAcceptRepository,
   ) {}
 
-  async readTodayStatistic(limit: number) {
+  async readTodayStatistic(statisticQueryDto: StatisticRequestDto) {
     const ranking = await this.redisService.zrevrange(
       redisKeys.FEED_TREND_KEY,
       0,
-      limit - 1,
+      statisticQueryDto.limit - 1,
       'WITHSCORES',
     );
     const todayFeedViews: Partial<Feed>[] = [];
@@ -44,9 +45,10 @@ export class StatisticService {
     return StatisticTodayResponseDto.toResponseDtoArray(todayFeedViews);
   }
 
-  async readAllStatistic(limit: number) {
-    const ranking =
-      await this.feedRepository.findAllStatisticsOrderByViewCount(limit);
+  async readAllStatistic(statisticQueryDto: StatisticRequestDto) {
+    const ranking = await this.feedRepository.findAllStatisticsOrderByViewCount(
+      statisticQueryDto.limit,
+    );
     return StatisticAllResponseDto.toResponseDtoArray(ranking);
   }
 

--- a/server/test/admin/e2e/login.e2e-spec.ts
+++ b/server/test/admin/e2e/login.e2e-spec.ts
@@ -1,26 +1,22 @@
 import { INestApplication } from '@nestjs/common';
-import { AdminService } from '../../../src/admin/service/admin.service';
 import { LoginAdminRequestDto } from '../../../src/admin/dto/request/login-admin.dto';
 import * as request from 'supertest';
-import { RegisterAdminRequestDto } from '../../../src/admin/dto/request/register-admin.dto';
+import { AdminRepository } from '../../../src/admin/repository/admin.repository';
+import { AdminFixture } from '../../fixture/admin.fixture';
 describe('POST api/admin/login E2E Test', () => {
   let app: INestApplication;
-  let adminService: AdminService;
-  const registerAdminDto: RegisterAdminRequestDto = {
-    loginId: 'testAdminId',
-    password: 'testAdminPassword!',
-  };
 
   beforeAll(async () => {
     app = global.testApp;
-    adminService = app.get(AdminService);
-    await adminService.createAdmin(registerAdminDto);
+    const adminRepository = app.get(AdminRepository);
+    await adminRepository.insert(await AdminFixture.createAdminFixture());
   });
+
   it('등록된 계정이면 정상적으로 로그인할 수 있다.', async () => {
     //given
     const loginAdminDto: LoginAdminRequestDto = {
-      loginId: 'testAdminId',
-      password: 'testAdminPassword!',
+      loginId: 'test1234',
+      password: 'test1234!',
     };
 
     //when
@@ -37,7 +33,7 @@ describe('POST api/admin/login E2E Test', () => {
     //given
     const loginWrongAdminIdDto: LoginAdminRequestDto = {
       loginId: 'testWrongAdminId',
-      password: 'testAdminPassword!',
+      password: 'test1234!',
     };
 
     //when
@@ -52,9 +48,10 @@ describe('POST api/admin/login E2E Test', () => {
   it('비밀번호가 다르다면 401 UnAuthorized 예외가 발생한다.', async () => {
     //given
     const loginWrongAdminPasswordDto: LoginAdminRequestDto = {
-      loginId: 'testAdminId',
+      loginId: 'test1234',
       password: 'testWrongAdminPassword!',
     };
+
     //when
     const response = await request(app.getHttpServer())
       .post('/api/admin/login')

--- a/server/test/admin/e2e/register.e2e-spec.ts
+++ b/server/test/admin/e2e/register.e2e-spec.ts
@@ -1,28 +1,26 @@
 import { INestApplication } from '@nestjs/common';
-import { AdminService } from '../../../src/admin/service/admin.service';
 import { LoginAdminRequestDto } from '../../../src/admin/dto/request/login-admin.dto';
 import { RegisterAdminRequestDto } from '../../../src/admin/dto/request/register-admin.dto';
 import * as request from 'supertest';
+import { AdminFixture } from '../../fixture/admin.fixture';
+import { AdminRepository } from '../../../src/admin/repository/admin.repository';
 
 describe('POST api/admin/register E2E Test', () => {
   let app: INestApplication;
-  let adminService: AdminService;
 
-  //given
   const loginAdminDto: LoginAdminRequestDto = {
-    loginId: 'testAdminId',
-    password: 'testAdminPassword!',
+    loginId: 'test1234',
+    password: 'test1234!',
   };
-  const registerAdminDto: RegisterAdminRequestDto = {
-    loginId: 'testNewAdminId',
-    password: 'testNewAdminPassword!',
-  };
+
+  const newAdminDto = new RegisterAdminRequestDto();
+  newAdminDto.loginId = 'testNewAdminId';
+  newAdminDto.password = 'testNewAdminPassword!';
 
   beforeAll(async () => {
     app = global.testApp;
-    adminService = app.get(AdminService);
-
-    await adminService.createAdmin(loginAdminDto);
+    const adminRepository = app.get(AdminRepository);
+    await adminRepository.insert(await AdminFixture.createAdminFixture());
   });
 
   it('관리자가 로그인되어 있으면 다른 관리자 계정 회원가입을 할 수 있다.', async () => {
@@ -31,9 +29,7 @@ describe('POST api/admin/register E2E Test', () => {
 
     //when
     await agent.post('/api/admin/login').send(loginAdminDto);
-    const response = await agent
-      .post('/api/admin/register')
-      .send(registerAdminDto);
+    const response = await agent.post('/api/admin/register').send(newAdminDto);
 
     //then
     expect(response.status).toBe(201);
@@ -45,27 +41,17 @@ describe('POST api/admin/register E2E Test', () => {
 
     //when
     await agent.post('/api/admin/login').send(loginAdminDto);
-    const response = await agent
-      .post('/api/admin/register')
-      .send(registerAdminDto);
+    const response = await agent.post('/api/admin/register').send(newAdminDto);
 
     //then
     expect(response.status).toBe(409);
   });
 
   it('관리자가 로그아웃 상태면 401 UnAuthorized 예외가 발생한다.', async () => {
-    //given
-    const registerAdminDto: RegisterAdminRequestDto = {
-      loginId: 'testNewAdminId',
-      password: 'testNewAdminPassword!',
-    };
-
     const agent = request.agent(app.getHttpServer());
 
     //when
-    const response = await agent
-      .post('/api/admin/register')
-      .send(registerAdminDto);
+    const response = await agent.post('/api/admin/register').send(newAdminDto);
 
     //then
     expect(response.status).toBe(401);

--- a/server/test/admin/e2e/sessionId.e2e-spec.ts
+++ b/server/test/admin/e2e/sessionId.e2e-spec.ts
@@ -1,24 +1,22 @@
 import { INestApplication } from '@nestjs/common';
-import { AdminService } from '../../../src/admin/service/admin.service';
-import { LoginAdminRequestDto } from '../../../src/admin/dto/request/login-admin.dto';
 import * as request from 'supertest';
 import { v4 as uuidv4 } from 'uuid';
+import { LoginAdminRequestDto } from '../../../src/admin/dto/request/login-admin.dto';
+import { AdminRepository } from '../../../src/admin/repository/admin.repository';
+import { AdminFixture } from '../../fixture/admin.fixture';
 
 describe('GET api/admin/sessionId E2E Test', () => {
   let app: INestApplication;
-  let adminService: AdminService;
 
-  //given
   const loginAdminDto: LoginAdminRequestDto = {
-    loginId: 'testAdminId',
-    password: 'testAdminPassword!',
+    loginId: 'test1234',
+    password: 'test1234!',
   };
 
   beforeAll(async () => {
     app = global.testApp;
-    adminService = app.get(AdminService);
-
-    await adminService.createAdmin(loginAdminDto);
+    const adminRepository = app.get(AdminRepository);
+    await adminRepository.insert(await AdminFixture.createAdminFixture());
   });
 
   it('쿠키의 session id가 유효하다면 관리자를 로그인 상태로 취급한다.', async () => {

--- a/server/test/fixture/admin.fixture.ts
+++ b/server/test/fixture/admin.fixture.ts
@@ -1,13 +1,18 @@
 import { Admin } from '../../src/admin/entity/admin.entity';
+import * as bcrypt from 'bcrypt';
 
 export class AdminFixture {
   static readonly GENERAL_ADMIN = {
     loginId: 'test1234',
-    password: '$2b$10$TGsf41ADKaziH5NgaDwec.JLue60QHk8DIZrFnJ9S6dZObN5humAe', // test1234!
+    password: 'test1234!',
   };
-  static createAdminFixture(overwrites: Partial<Admin> = {}): Admin {
+  static async createAdminFixture(
+    overwrites: Partial<Admin> = {},
+  ): Promise<Admin> {
     const admin = new Admin();
     Object.assign(admin, this.GENERAL_ADMIN);
-    return Object.assign(admin, overwrites);
+    Object.assign(admin, overwrites);
+    admin.password = await bcrypt.hash(admin.password, 10);
+    return admin;
   }
 }


### PR DESCRIPTION
# 🔨 테스크

### 작업 필요성

-   테스트를 마지막쯤에 작성해서 너무 막 적은 감이 있었다.
- Admin 도메인에 대해 적용해보고 팀원들이 동의할 경우 다른 도메인에도 적용할 계획이다. PR 룰 (추가, 삭제 400줄 이내)를 지키기 위해 Admin 도메인에 사전 적용한다.
- Admin 테스트 픽스처를 활용하지 않고 있었다.
- 테스트 사전 단계(beforeAll)에서 서비스 계층으로 테스트 데이터를 삽입했다. 그냥 Repository 계층에서 바로 삽입하면 됐었다.

### 다음 작업
-  feed 도메인 작업
-  rss 도메인 작업
- statistic 도메인 작업

### Admin 픽스처 수정
- 비밀번호를 암호화한 걸 들고 있을 이유가 없다.
- 매번 사용할 때마다 암호화한 결과를 개발자가 알고 있어야 하는데, 상당히 번거롭다. 서비스에 실제로 대입을 해봐야한다. 그렇기에 비밀번호 평문을 넣을때 암호화되게 하여 사용성을 높였다.

### 컨트롤러 -> 서비스 계층 DTO, 개별 인자
- DTO를 사용해야 팀에서 나온 방식인 DTO -> ENTITY를 수행하는 함수를 사용할 수 있었다. 코드 일관성을 위해 전부 DTO를 전달하도록 변경했다.
- Parameter, Body를 함께 받는 곳은 확인하기 어려워 변수명 가운데 Param, Query, Body를 추가해서 이해도를 향상시켰다.

# 📋 작업 내용

-   Admin Repository 전처리, 데이터 삽입 함수 제거
- Admin 회원가입 dto `toEntity` 함수 추가
- bcrypt types 설치
- Admin 픽스처 활용도 향상
- Admin 도메인 DTO 변수 명칭 자세하게 변경
