### PR TITLE
♻️ refactor: feed 도메인 repository 함수 재사용성 향상, 테스트 코드 일관성, 최적화

### DIFF
--- a/server/src/feed/dto/request/feed-pagination.dto.ts
+++ b/server/src/feed/dto/request/feed-pagination.dto.ts
@@ -17,4 +17,8 @@ export class FeedPaginationRequestDto {
   })
   @Type(() => Number)
   limit?: number = 12;
+
+  constructor(partial: Partial<FeedPaginationRequestDto>) {
+    Object.assign(this, partial);
+  }
 }

--- a/server/src/feed/dto/request/feed-update.dto.ts
+++ b/server/src/feed/dto/request/feed-update.dto.ts
@@ -1,6 +1,6 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { Type } from 'class-transformer';
-import { IsInt } from 'class-validator';
+import { IsInt, Min } from 'class-validator';
 
 export class FeedViewUpdateRequestDto {
   @ApiProperty({
@@ -10,6 +10,11 @@ export class FeedViewUpdateRequestDto {
   @IsInt({
     message: '정수를 입력해주세요.',
   })
+  @Min(1, { message: '조회하고자 하는 피드 ID는 1보다 커야합니다.' })
   @Type(() => Number)
   feedId: number;
+
+  constructor(partial: Partial<FeedViewUpdateRequestDto>) {
+    Object.assign(this, partial);
+  }
 }

--- a/server/src/feed/repository/feed.repository.ts
+++ b/server/src/feed/repository/feed.repository.ts
@@ -67,8 +67,7 @@ export class FeedViewRepository extends Repository<FeedView> {
     super(FeedView, dataSource.createEntityManager());
   }
 
-  async findFeedPagination(queryFeedDto: FeedPaginationRequestDto) {
-    const { lastId, limit } = queryFeedDto;
+  async findFeedPagination(lastId: number, limit: number) {
     const query = this.createQueryBuilder()
       .where((qb) => {
         if (lastId) {

--- a/server/src/feed/service/feed.service.ts
+++ b/server/src/feed/service/feed.service.ts
@@ -40,8 +40,10 @@ export class FeedService {
   ) {}
 
   async readFeedPagination(queryFeedDto: FeedPaginationRequestDto) {
-    const feedList =
-      await this.feedViewRepository.findFeedPagination(queryFeedDto);
+    const feedList = await this.feedViewRepository.findFeedPagination(
+      queryFeedDto.lastId,
+      queryFeedDto.limit,
+    );
     const hasMore = this.existNextFeed(feedList, queryFeedDto.limit);
     if (hasMore) feedList.pop();
     const lastId = this.getLastIdFromFeedList(feedList);

--- a/server/test/feed/dto/feed-pagination.dto.spec.ts
+++ b/server/test/feed/dto/feed-pagination.dto.spec.ts
@@ -2,19 +2,14 @@ import { validate } from 'class-validator';
 import { FeedPaginationRequestDto } from '../../../src/feed/dto/request/feed-pagination.dto';
 
 describe('FeedPaginationRequestDto Test', () => {
-  //given
-  let queryFeedDto: FeedPaginationRequestDto;
-
-  beforeEach(() => {
-    queryFeedDto = new FeedPaginationRequestDto();
-  });
-
   it('limit에 1보다 작은 값을 입력하면 유효성 검사에 실패한다.', async () => {
     //given
-    queryFeedDto.limit = -1;
+    const feedPaginationQueryDto = new FeedPaginationRequestDto({
+      limit: -1,
+    });
 
     //when
-    const errors = await validate(queryFeedDto);
+    const errors = await validate(feedPaginationQueryDto);
 
     //then
     expect(errors).toHaveLength(1);
@@ -23,10 +18,12 @@ describe('FeedPaginationRequestDto Test', () => {
 
   it('limit에 자연수가 아닌 실수를 입력하면 유효성 검사에 실패한다.', async () => {
     //given
-    queryFeedDto.limit = 1.254;
+    const feedPaginationQueryDto = new FeedPaginationRequestDto({
+      limit: 1.254,
+    });
 
     //when
-    const errors = await validate(queryFeedDto);
+    const errors = await validate(feedPaginationQueryDto);
 
     //then
     expect(errors).toHaveLength(1);
@@ -35,10 +32,12 @@ describe('FeedPaginationRequestDto Test', () => {
 
   it('limit에 문자열을 입력하면 유효성 검사에 실패한다.', async () => {
     //given
-    queryFeedDto.limit = 'abcdefg' as any;
+    const feedPaginationQueryDto = new FeedPaginationRequestDto({
+      limit: 'abcdefg' as any,
+    });
 
     //when
-    const errors = await validate(queryFeedDto);
+    const errors = await validate(feedPaginationQueryDto);
 
     //then
     expect(errors).toHaveLength(1);
@@ -47,10 +46,12 @@ describe('FeedPaginationRequestDto Test', () => {
 
   it('lastId에 음수를 입력하면 유효성 검사에 실패한다.', async () => {
     //given
-    queryFeedDto.lastId = -1;
+    const feedPaginationQueryDto = new FeedPaginationRequestDto({
+      lastId: -1,
+    });
 
     //when
-    const errors = await validate(queryFeedDto);
+    const errors = await validate(feedPaginationQueryDto);
 
     //then
     expect(errors).toHaveLength(1);
@@ -59,10 +60,12 @@ describe('FeedPaginationRequestDto Test', () => {
 
   it('lastId에 자연수가 아닌 실수를 입력하면 유효성 검사에 실패한다.', async () => {
     //given
-    queryFeedDto.lastId = 1.254;
+    const feedPaginationQueryDto = new FeedPaginationRequestDto({
+      lastId: 1.254,
+    });
 
     //when
-    const errors = await validate(queryFeedDto);
+    const errors = await validate(feedPaginationQueryDto);
 
     //then
     expect(errors).toHaveLength(1);
@@ -71,10 +74,12 @@ describe('FeedPaginationRequestDto Test', () => {
 
   it('lastId에 문자열을 입력하면 유효성 검사에 실패한다.', async () => {
     //given
-    queryFeedDto.lastId = 'abcdefg' as any;
+    const feedPaginationQueryDto = new FeedPaginationRequestDto({
+      lastId: 'abcdefg' as any,
+    });
 
     //when
-    const errors = await validate(queryFeedDto);
+    const errors = await validate(feedPaginationQueryDto);
 
     //then
     expect(errors).toHaveLength(1);

--- a/server/test/feed/dto/feed-update.dto.spec.ts
+++ b/server/test/feed/dto/feed-update.dto.spec.ts
@@ -1,0 +1,46 @@
+import { validate } from 'class-validator';
+import { FeedViewUpdateRequestDto } from '../../../src/feed/dto/request/feed-update.dto';
+
+describe('FeedViewUpdateRequestDto Test', () => {
+  it('feedId에 1보다 작은 값을 입력하면 유효성 검사에 실패한다.', async () => {
+    //given
+    const feedPaginationQueryDto = new FeedViewUpdateRequestDto({
+      feedId: -1,
+    });
+
+    //when
+    const errors = await validate(feedPaginationQueryDto);
+
+    //then
+    expect(errors).toHaveLength(1);
+    expect(errors[0].constraints).toHaveProperty('min');
+  });
+
+  it('feedId에 자연수가 아닌 실수를 입력하면 유효성 검사에 실패한다.', async () => {
+    //given
+    const feedPaginationQueryDto = new FeedViewUpdateRequestDto({
+      feedId: 1.254,
+    });
+
+    //when
+    const errors = await validate(feedPaginationQueryDto);
+
+    //then
+    expect(errors).toHaveLength(1);
+    expect(errors[0].constraints).toHaveProperty('isInt');
+  });
+
+  it('feedId에 문자열을 입력하면 유효성 검사에 실패한다.', async () => {
+    //given
+    const feedPaginationQueryDto = new FeedViewUpdateRequestDto({
+      feedId: 'abcdefg' as any,
+    });
+
+    //when
+    const errors = await validate(feedPaginationQueryDto);
+
+    //then
+    expect(errors).toHaveLength(1);
+    expect(errors[0].constraints).toHaveProperty('isInt');
+  });
+});

--- a/server/test/feed/e2e/feed.e2e-spec.ts
+++ b/server/test/feed/e2e/feed.e2e-spec.ts
@@ -23,7 +23,7 @@ describe('GET api/feed E2E Test', () => {
       return FeedFixture.createFeedFixture(blog, _, i + 1);
     });
 
-    await Promise.all([feedRepository.save(feeds)]);
+    await feedRepository.insert(feeds);
   });
 
   it('lastId가 없으면 최신 피드부터 전송한다.', async () => {

--- a/server/test/feed/e2e/feed.e2e-spec.ts
+++ b/server/test/feed/e2e/feed.e2e-spec.ts
@@ -4,6 +4,7 @@ import { FeedFixture } from '../../fixture/feed.fixture';
 import { FeedRepository } from '../../../src/feed/repository/feed.repository';
 import { RssAcceptRepository } from '../../../src/rss/repository/rss.repository';
 import { RssAcceptFixture } from '../../fixture/rssAccept.fixture';
+import { FeedPaginationRequestDto } from '../../../src/feed/dto/request/feed-pagination.dto';
 
 describe('GET api/feed E2E Test', () => {
   let app: INestApplication;
@@ -27,12 +28,14 @@ describe('GET api/feed E2E Test', () => {
 
   it('lastId가 없으면 최신 피드부터 전송한다.', async () => {
     //given
-    const testQuery = { limit: 5 };
+    const feedPaginationQueryDto = new FeedPaginationRequestDto({
+      limit: 5,
+    });
 
     //when
     const response = await request(app.getHttpServer())
       .get('/api/feed')
-      .query(testQuery);
+      .query(feedPaginationQueryDto);
 
     //then
     expect(response.status).toBe(200);
@@ -49,21 +52,24 @@ describe('GET api/feed E2E Test', () => {
 
   it('lastId가 있으면 해당 피드 다음 순서부터 전송한다.', async () => {
     //given
-    const testQuery = { limit: 5, lastId: 11 };
+    const feedPaginationQueryDto = new FeedPaginationRequestDto({
+      limit: 5,
+      lastId: 11,
+    });
 
     //when
     const response = await request(app.getHttpServer())
       .get('/api/feed')
-      .query(testQuery);
+      .query(feedPaginationQueryDto);
 
     //then
     expect(response.status).toBe(200);
     expect(response.body.data.result.map((feed) => feed.id)).toStrictEqual([
-      testQuery.lastId - 1,
-      testQuery.lastId - 2,
-      testQuery.lastId - 3,
-      testQuery.lastId - 4,
-      testQuery.lastId - 5,
+      feedPaginationQueryDto.lastId - 1,
+      feedPaginationQueryDto.lastId - 2,
+      feedPaginationQueryDto.lastId - 3,
+      feedPaginationQueryDto.lastId - 4,
+      feedPaginationQueryDto.lastId - 5,
     ]);
     expect(response.body.data.hasMore).toBe(true);
     expect(response.body.data.lastId).toBe(6);
@@ -71,25 +77,28 @@ describe('GET api/feed E2E Test', () => {
 
   it('limit의 크기보다 남은 Feed의 개수가 적은 경우면 정상적으로 동작한다.', async () => {
     //given
-    const testQuery = { limit: 15, lastId: 10 };
+    const feedPaginationQueryDto = new FeedPaginationRequestDto({
+      limit: 15,
+      lastId: 10,
+    });
 
     //when
     const response = await request(app.getHttpServer())
       .get('/api/feed')
-      .query(testQuery);
+      .query(feedPaginationQueryDto);
 
     //then
     expect(response.status).toBe(200);
     expect(response.body.data.result.map((feed) => feed.id)).toStrictEqual([
-      testQuery.lastId - 1,
-      testQuery.lastId - 2,
-      testQuery.lastId - 3,
-      testQuery.lastId - 4,
-      testQuery.lastId - 5,
-      testQuery.lastId - 6,
-      testQuery.lastId - 7,
-      testQuery.lastId - 8,
-      testQuery.lastId - 9,
+      feedPaginationQueryDto.lastId - 1,
+      feedPaginationQueryDto.lastId - 2,
+      feedPaginationQueryDto.lastId - 3,
+      feedPaginationQueryDto.lastId - 4,
+      feedPaginationQueryDto.lastId - 5,
+      feedPaginationQueryDto.lastId - 6,
+      feedPaginationQueryDto.lastId - 7,
+      feedPaginationQueryDto.lastId - 8,
+      feedPaginationQueryDto.lastId - 9,
     ]);
     expect(response.body.data.hasMore).toBe(false);
     expect(response.body.data.lastId).toBe(1);
@@ -97,12 +106,15 @@ describe('GET api/feed E2E Test', () => {
 
   it('남은 피드 개수가 0이면 lastId 0, 빈 배열로 응답한다.', async () => {
     //given
-    const testQuery = { limit: 15, lastId: 1 };
+    const feedPaginationQueryDto = new FeedPaginationRequestDto({
+      limit: 15,
+      lastId: 1,
+    });
 
     //when
     const response = await request(app.getHttpServer())
       .get('/api/feed')
-      .query(testQuery);
+      .query(feedPaginationQueryDto);
 
     //then
     expect(response.status).toBe(200);

--- a/server/test/feed/e2e/feedId.e2e-spec.ts
+++ b/server/test/feed/e2e/feedId.e2e-spec.ts
@@ -29,7 +29,7 @@ describe('POST /api/feed/:feedId E2E Test', () => {
     });
 
     await Promise.all([
-      feedRepository.save(feeds),
+      feedRepository.insert(feeds),
       redisService.sadd(`feed:${testFeedId}:ip`, testIp),
     ]);
   });

--- a/server/test/feed/e2e/trend.e2e-spec.ts
+++ b/server/test/feed/e2e/trend.e2e-spec.ts
@@ -25,7 +25,7 @@ describe('SSE /api/trend/sse E2E Test', () => {
     for (let i = 1; i <= 2; i++) {
       feeds.push(FeedFixture.createFeedFixture(blog, {}, i));
     }
-    await Promise.all([feedRepository.save(feeds), app.listen(7000)]);
+    await Promise.all([feedRepository.insert(feeds), app.listen(7000)]);
   });
 
   it('최초 연결이 되면 트랜드 데이터를 최대 4개 받을 수 있다.', async () => {


### PR DESCRIPTION
# 🔨 테스크

### Repository 계층 함수를 재사용 가능하게 하려면 어떻게 해야 할까?

-   어느 한 타입으로 지정해두면 Repository 계층 함수를 재사용할 수 없다.
- Repository 계층에 있는 함수를 재사용할 일이 있으려나 싶긴 하지만, 혹시나 하는 마음에 작업한다. 
- Select 함수들은 DTO가 아닌 개별 인자값으로 받게 하고, INSERT 하는 부분들은 DTO에서 Entity로 바꿔 삽입할 수 있도록 한다. 그러기 위해서는 전처리 작업 했던 부분을 롤백해야 한다.

# 📋 작업 내용

-   feed 도메인 Repository 계층 함수들 단일 인자 값으로 변경
- feed 도메인 DTO 생성자 추가
- feed 도메인 조회수 증가 DTO 테스트 코드 작성
- typeorm save -> insert로 변경하여 성능 개선
