### PR TITLE
♻️ refactor: rss 도메인 repository 함수 재사용성 향상, 테스트 코드 일관성, 최적화

### DIFF
--- a/server/src/rss/dto/request/rss-management.dto.ts
+++ b/server/src/rss/dto/request/rss-management.dto.ts
@@ -7,4 +7,8 @@ export class RssManagementRequestDto {
   })
   @Type(() => Number)
   id: number;
+
+  constructor(partial: Partial<RssManagementRequestDto>) {
+    Object.assign(this, partial);
+  }
 }

--- a/server/src/rss/dto/request/rss-register.dto.ts
+++ b/server/src/rss/dto/request/rss-register.dto.ts
@@ -65,15 +65,6 @@ export class RssRegisterRequestDto {
     Object.assign(this, partial);
   }
 
-  static from(rss: RssInformation) {
-    return new RssRegisterRequestDto({
-      blog: rss.name,
-      name: rss.userName,
-      email: rss.email,
-      rssUrl: rss.rssUrl,
-    });
-  }
-
   toEntity() {
     const rss = new Rss();
     rss.name = this.blog;

--- a/server/src/rss/dto/request/rss-register.dto.ts
+++ b/server/src/rss/dto/request/rss-register.dto.ts
@@ -1,6 +1,6 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { IsEmail, IsNotEmpty, IsString, IsUrl, Length } from 'class-validator';
-import { RssInformation } from '../../entity/rss.entity';
+import { Rss, RssInformation } from '../../entity/rss.entity';
 
 export class RssRegisterRequestDto {
   @ApiProperty({
@@ -72,5 +72,14 @@ export class RssRegisterRequestDto {
       email: rss.email,
       rssUrl: rss.rssUrl,
     });
+  }
+
+  toEntity() {
+    const rss = new Rss();
+    rss.name = this.blog;
+    rss.userName = this.name;
+    rss.email = this.email;
+    rss.rssUrl = this.rssUrl;
+    return rss;
   }
 }

--- a/server/src/rss/dto/request/rss-reject.dto.ts
+++ b/server/src/rss/dto/request/rss-reject.dto.ts
@@ -10,7 +10,7 @@ export class RejectRssRequestDto {
   @IsString({ message: '거부 사유를 문자열로 작성해주세요.' })
   description: string;
 
-  constructor(description: string) {
-    this.description = description;
+  constructor(partial: Partial<RejectRssRequestDto>) {
+    Object.assign(this, partial);
   }
 }

--- a/server/src/rss/repository/rss.repository.ts
+++ b/server/src/rss/repository/rss.repository.ts
@@ -8,17 +8,6 @@ export class RssRepository extends Repository<Rss> {
   constructor(private dataSource: DataSource) {
     super(Rss, dataSource.createEntityManager());
   }
-
-  async insertNewRss(rssRegisterDto: RssRegisterRequestDto) {
-    const { blog, name, email, rssUrl } = rssRegisterDto;
-    const rssObj = this.create({
-      name: blog,
-      userName: name,
-      email,
-      rssUrl,
-    });
-    await this.save(rssObj);
-  }
 }
 
 @Injectable()

--- a/server/src/rss/service/feed-crawler.service.ts
+++ b/server/src/rss/service/feed-crawler.service.ts
@@ -18,7 +18,7 @@ export class FeedCrawlerService {
 
   async saveRssFeeds(feeds: Partial<Feed>[], newRssAccept: RssAccept) {
     feeds.forEach((feed) => (feed.blog = newRssAccept));
-    return await this.feedRepository.insert(feeds);
+    await this.feedRepository.insert(feeds);
   }
 
   private async fetchRss(rssUrl: string): Promise<Partial<Feed>[]> {

--- a/server/src/rss/service/rss.service.ts
+++ b/server/src/rss/service/rss.service.ts
@@ -50,7 +50,7 @@ export class RssService {
       );
     }
 
-    await this.rssRepository.insertNewRss(rssRegisterDto);
+    await this.rssRepository.insert(rssRegisterDto.toEntity());
   }
 
   async readAllRss() {

--- a/server/src/rss/service/rss.service.ts
+++ b/server/src/rss/service/rss.service.ts
@@ -52,7 +52,7 @@ export class RssService {
       );
     }
 
-    await this.rssRepository.insert(rssRegisterDto.toEntity());
+    await this.rssRepository.insert(rssRegisterBodyDto.toEntity());
   }
 
   async readAllRss() {

--- a/server/test/rss/dto/rss-management.dto.spec.ts
+++ b/server/test/rss/dto/rss-management.dto.spec.ts
@@ -5,8 +5,7 @@ import { RssManagementRequestDto } from '../../../src/rss/dto/request/rss-manage
 describe('RssManagementDto Test', () => {
   it('Rss관리 API의 PathVariable이 정수가 아닐 경우', async () => {
     // given
-    const dto = new RssManagementRequestDto();
-    dto.id = 'abc' as any;
+    const dto = new RssManagementRequestDto({ id: 'abc' as any });
 
     // when
     const errors = await validate(dto);

--- a/server/test/rss/e2e/accept.e2e-spec.ts
+++ b/server/test/rss/e2e/accept.e2e-spec.ts
@@ -33,10 +33,11 @@ describe('Rss Accept E2E Test', () => {
     describe('정상적인 요청을 한다.', () => {
       it('정상적으로 RSS를 승인한다.', async () => {
         // given
-        const rssFixture = RssFixture.createRssFixture({
-          rssUrl: 'https://v2.velog.io/rss/@seok3765',
-        });
-        const rss = await rssRepository.save(rssFixture);
+        const rss = await rssRepository.save(
+          RssFixture.createRssFixture({
+            rssUrl: 'https://v2.velog.io/rss/@seok3765',
+          }),
+        );
 
         // when
         const response = await request(app.getHttpServer())

--- a/server/test/rss/e2e/history/accept.e2e-spec.ts
+++ b/server/test/rss/e2e/history/accept.e2e-spec.ts
@@ -16,7 +16,7 @@ describe('GET /api/rss/history/accept E2E Test', () => {
       rssAccepts.push(RssAcceptFixture.createRssAcceptFixture({}, i));
     }
     await Promise.all([
-      rssAcceptRepository.save(rssAccepts),
+      rssAcceptRepository.insert(rssAccepts),
       redisService.sadd('auth:sid', 'test1234'),
     ]);
   });

--- a/server/test/rss/e2e/history/reject.e2e-spec.ts
+++ b/server/test/rss/e2e/history/reject.e2e-spec.ts
@@ -16,7 +16,7 @@ describe('GET /api/rss/history/reject E2E Test', () => {
       rssAccepts.push(RssRejectFixture.createRssRejectFixture({}, i));
     }
     await Promise.all([
-      rssRejectRepository.save(rssAccepts),
+      rssRejectRepository.insert(rssAccepts),
       redisService.sadd('auth:sid', 'test1234'),
     ]);
   });

--- a/server/test/rss/e2e/reject.e2e-spec.ts
+++ b/server/test/rss/e2e/reject.e2e-spec.ts
@@ -37,7 +37,9 @@ describe('Rss Reject E2E Test', () => {
         const REJECT_REASON = '거절 사유';
         const rssFixture = RssFixture.createRssFixture();
         const rss = await rssRepository.save(rssFixture);
-        const rejectRssDto = new RejectRssRequestDto(REJECT_REASON);
+        const rejectRssDto = new RejectRssRequestDto({
+          description: REJECT_REASON,
+        });
 
         // when
         const response = await request(app.getHttpServer())
@@ -59,7 +61,9 @@ describe('Rss Reject E2E Test', () => {
       it('존재하지 않는 rss를 거절할 때', async () => {
         // given
         const REJECT_REASON = '거절 사유';
-        const rejectRssDto = new RejectRssRequestDto(REJECT_REASON);
+        const rejectRssDto = new RejectRssRequestDto({
+          description: REJECT_REASON,
+        });
 
         // when
         const response = await request(app.getHttpServer())

--- a/server/test/rss/e2e/reject.e2e-spec.ts
+++ b/server/test/rss/e2e/reject.e2e-spec.ts
@@ -35,8 +35,7 @@ describe('Rss Reject E2E Test', () => {
       it('정상적으로 RSS를 거절한다.', async () => {
         // given
         const REJECT_REASON = '거절 사유';
-        const rssFixture = RssFixture.createRssFixture();
-        const rss = await rssRepository.save(rssFixture);
+        const rss = await rssRepository.save(RssFixture.createRssFixture());
         const rejectRssDto = new RejectRssRequestDto({
           description: REJECT_REASON,
         });

--- a/server/test/rss/e2e/rss.e2e-spec.ts
+++ b/server/test/rss/e2e/rss.e2e-spec.ts
@@ -28,9 +28,12 @@ describe('/api/rss E2E Test', () => {
   describe('POST /api/rss E2E Test', () => {
     it('정상적인 요청이 들어왔다면 올바른 응답을 한다.', async () => {
       // given
-      const requestDto = RssRegisterRequestDto.from(
-        RssFixture.createRssFixture(),
-      );
+      const requestDto = new RssRegisterRequestDto({
+        blog: 'blog1',
+        name: 'name1',
+        email: 'test1@test.com',
+        rssUrl: 'https://example1.com/rss',
+      });
 
       // when
       const response = await request(app.getHttpServer())
@@ -43,9 +46,12 @@ describe('/api/rss E2E Test', () => {
 
     it('이미 신청한 RSS를 또 신청한다면 거부를 한다.', async () => {
       // given
-      const requestDto = RssRegisterRequestDto.from(
-        RssFixture.createRssFixture(),
-      );
+      const requestDto = new RssRegisterRequestDto({
+        blog: 'blog1',
+        name: 'name1',
+        email: 'test1@test.com',
+        rssUrl: 'https://example1.com/rss',
+      });
       await request(app.getHttpServer()).post('/api/rss').send(requestDto);
 
       // when
@@ -62,7 +68,12 @@ describe('/api/rss E2E Test', () => {
       const acceptedRss = await rssAcceptRepository.save(
         RssAcceptFixture.createRssAcceptFixture(),
       );
-      const rssRegisterDto = RssRegisterRequestDto.from(acceptedRss);
+      const rssRegisterDto = new RssRegisterRequestDto({
+        blog: acceptedRss.name,
+        name: acceptedRss.userName,
+        email: acceptedRss.email,
+        rssUrl: acceptedRss.rssUrl,
+      });
 
       // when
       const response = await request(app.getHttpServer())

--- a/server/test/rss/e2e/rss.e2e-spec.ts
+++ b/server/test/rss/e2e/rss.e2e-spec.ts
@@ -96,8 +96,9 @@ describe('/api/rss E2E Test', () => {
 
       it('등록된 RSS가 존재할 경우 해당 데이터를 반환한다.', async () => {
         // given
-        const rss = RssFixture.createRssFixture();
-        const expectedResult = await rssRepository.save(rss);
+        const expectedResult = await rssRepository.save(
+          RssFixture.createRssFixture(),
+        );
 
         // when
         const response = await request(app.getHttpServer()).get('/api/rss');


### PR DESCRIPTION
# 🔨 테스크

### TypeORM insert vs save 차이
#### save 동작 원리
1. SELECT 쿼리를 통해 엔티티 객체에 정의된 PK를 사용하여 DB 내 엔티티 존재 여부를 확인한다.
2. 없을 경우 INSERT를 수행한다.
3. 있을 경우 UPDATE를 수행한다.
4. 변경 또는 삽입된 데이터를 SELECT로 조회해서 엔티티로 반환한다.

#### insert 동작 원리
1. 냅다 넣는다.
2. 메타 정보만 반환한다.

결론: insert가 성능이 빠르다. 다만, 반환되어야 하는 엔티티가 필요하다면 save를 사용해야 한다.

### from 함수 제거
- 다른 DTO들은 전부 생성자로 구현되어 있는데, RssRegisterRequestDto만 from 함수가 존재했다.
- 테스트 코드 때문에 원본 코드에 테스트를 위한 특수 함수가 존재하는 건 오히려 원본 코드에 혼란을 주는 느낌이 들었다. 어디서 사용했는지 사용처를 알아야 하는데, 테스트에 있는 게 이상하다고 판단했다.

# 📋 작업 내용

-   typeorm save -> insert로 변경하여 성능 개선
- 테스트 코드 픽스처 라인 정리
- from 함수 제거
- 필요없는 return 제거
- rss 도메인 repository 재사용 가능하도록 개별 변수 인자로 변경
