### PR TITLE
♻️ refactor: 채팅, 헤더 반응형 작업

### DIFF
--- a/client/src/components/chat/ChatButton.tsx
+++ b/client/src/components/chat/ChatButton.tsx
@@ -2,11 +2,27 @@ import { MessageCircleMore, X } from "lucide-react";
 
 import { useSidebar } from "@/components/ui/sidebar";
 
+import { useSidebarStore } from "@/store/useSidebarStore";
+
 export default function ChatButton() {
   return <div className="flex items-center gap-2"></div>;
 }
 export function OpenChat() {
-  const { toggleSidebar } = useSidebar();
+  const { toggleSidebar, isMobile, setOpenMobile } = useSidebar();
+  if (isMobile) {
+    return (
+      <>
+        <button
+          onClick={() => {
+            setOpenMobile(true);
+          }}
+          className="w-full"
+        >
+          채팅
+        </button>
+      </>
+    );
+  }
 
   return (
     <button
@@ -19,9 +35,14 @@ export function OpenChat() {
 }
 export function CloseChat() {
   const { toggleSidebar } = useSidebar();
-
+  const { isOpen, setIsOpen } = useSidebarStore();
   return (
-    <button onClick={toggleSidebar}>
+    <button
+      onClick={() => {
+        toggleSidebar();
+        if (isOpen) setIsOpen();
+      }}
+    >
       <X size={16} />
     </button>
   );

--- a/client/src/components/chat/layout/ChatFooter.tsx
+++ b/client/src/components/chat/layout/ChatFooter.tsx
@@ -22,7 +22,7 @@ export default function ChatFooter() {
   useKeyboardShortcut("Enter", () => handleSendMessage(), false);
 
   return (
-    <SheetFooter className="flex items-center p-2">
+    <SheetFooter className="flex flex-row items-center p-2">
       <Input
         placeholder="메시지를 입력하세요"
         value={message}

--- a/client/src/components/chat/layout/ChatSection.tsx
+++ b/client/src/components/chat/layout/ChatSection.tsx
@@ -25,7 +25,7 @@ const RenderHistory = ({ chatHistory, isFull }: { chatHistory: ChatType[]; isFul
     <span className="flex flex-col gap-3 px-3">
       {chatHistory.map((item, index) => {
         const isSameUser = index > 0 && chatHistory[index - 1]?.username === item.username;
-        return <ChatItem key={item.timestamp} chatItem={item} isSameUser={isSameUser} />;
+        return <ChatItem key={index} chatItem={item} isSameUser={isSameUser} />;
       })}
     </span>
   );

--- a/client/src/components/layout/Header.tsx
+++ b/client/src/components/layout/Header.tsx
@@ -1,34 +1,20 @@
 import { useState } from "react";
-import { useNavigate } from "react-router-dom";
-
-import { AnimatePresence } from "framer-motion";
-import { Menu } from "lucide-react";
 
 import RssRegistrationModal from "@/components/RssRegistration/RssRegistrationModal";
-import SideButton from "@/components/layout/SideButton";
-import SideBar from "@/components/layout/Sidebar";
-import SearchButton from "@/components/search/SearchButton";
+import DesktopNavigation from "@/components/layout/navigation/DesktopNavigation";
+import MobileNavigation from "@/components/layout/navigation/MobileNavigation";
 import SearchModal from "@/components/search/SearchModal";
-import { Button } from "@/components/ui/button";
-import {
-  NavigationMenu,
-  NavigationMenuItem,
-  NavigationMenuList,
-  NavigationMenuLink,
-  navigationMenuTriggerStyle,
-} from "@/components/ui/navigation-menu";
-import { Sheet, SheetContent, SheetHeader, SheetTitle, SheetTrigger } from "@/components/ui/sheet";
 
 import { useCustomToast } from "@/hooks/common/useCustomToast.ts";
 import { useKeyboardShortcut } from "@/hooks/common/useKeyboardShortcut";
-
-import logo from "@/assets/logo-denamu-main.svg";
+import { useMediaQuery } from "@/hooks/common/useMediaQuery";
 
 import { TOAST_MESSAGES } from "@/constants/messages";
 
 export default function Header() {
   const [modals, setModals] = useState({ search: false, rss: false, login: false, chat: false });
   const { toast } = useCustomToast();
+  const isMobile = useMediaQuery("(max-width: 767px)");
   const toggleModal = (modalType: "search" | "rss" | "login" | "chat") => {
     if (modalType === "login") {
       toast(TOAST_MESSAGES.SERVICE_NOT_PREPARED);
@@ -40,92 +26,10 @@ export default function Header() {
 
   return (
     <div className="border-b border-primary/20">
-      <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
-        <div className="h-20 items-center overflow-hidden flex justify-between relative z-50">
-          {/* 로고 영역 */}
-          <button className="flex-shrink-0 relative z-50" onClick={() => location.reload()}>
-            <img className="h-14 w-auto cursor-pointer" src={logo} alt="Logo" />
-          </button>
-
-          {/* 중앙 검색 버튼 */}
-          <div className="absolute left-1/2 transform -translate-x-1/2 w-full flex justify-center z-40">
-            <SearchButton handleSearchModal={() => toggleModal("search")} />
-          </div>
-
-          {/* 내비게이션 */}
-          <div className="flex-shrink-0 z-50">
-            <DesktopNavigation toggleModal={toggleModal} />
-            <MobileNavigation toggleModal={toggleModal} />
-          </div>
-        </div>
-      </div>
-      <AnimatePresence>
-        {modals.rss && <RssRegistrationModal onClose={() => toggleModal("rss")} rssOpen={modals.rss} />}
-        {modals.search && <SearchModal onClose={() => toggleModal("search")} />}
-      </AnimatePresence>
-    </div>
-  );
-}
-
-function DesktopNavigation({ toggleModal }: { toggleModal: (modalType: "search" | "rss" | "login") => void }) {
-  const navigate = useNavigate();
-
-  return (
-    <div className="hidden md:flex md:items-center">
-      <NavigationMenu>
-        <NavigationMenuList>
-          <NavigationMenuItem>
-            <SideButton />
-          </NavigationMenuItem>
-          <NavigationMenuItem>
-            <NavigationMenuLink
-              className={`${navigationMenuTriggerStyle()} hover:text-primary hover:bg-primary/10`}
-              onClick={() => navigate("/about")}
-              href="#"
-            >
-              서비스 소개
-            </NavigationMenuLink>
-          </NavigationMenuItem>
-          <NavigationMenuItem>
-            <NavigationMenuLink
-              className={`${navigationMenuTriggerStyle()} hover:text-primary hover:bg-primary/10`}
-              onClick={() => toggleModal("login")}
-              href="#"
-            >
-              로그인
-            </NavigationMenuLink>
-          </NavigationMenuItem>
-          <NavigationMenuItem>
-            <Button variant="default" onClick={() => toggleModal("rss")} className="bg-primary hover:bg-primary/90">
-              블로그 등록
-            </Button>
-          </NavigationMenuItem>
-        </NavigationMenuList>
-      </NavigationMenu>
-    </div>
-  );
-}
-
-function MobileNavigation({ toggleModal }: { toggleModal: (modalType: "search" | "rss" | "login") => void }) {
-  return (
-    <div className="md:hidden">
-      <Sheet>
-        <SheetTrigger asChild>
-          <Button variant="outline" size="icon" className="hover:border-primary hover:text-primary">
-            <Menu className="h-4 w-4" />
-          </Button>
-        </SheetTrigger>
-        <SheetContent>
-          <SheetHeader>
-            <SheetTitle className="text-primary">메뉴</SheetTitle>
-          </SheetHeader>
-          <SideBar
-            handleRssModal={() => toggleModal("rss")}
-            handleSearchModal={() => toggleModal("search")}
-            handleLoginModal={() => toggleModal("login")}
-          />
-        </SheetContent>
-      </Sheet>
+      {isMobile ? <MobileNavigation toggleModal={toggleModal} /> : <DesktopNavigation toggleModal={toggleModal} />}
+      <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8"></div>
+      {modals.rss && <RssRegistrationModal onClose={() => toggleModal("rss")} rssOpen={modals.rss} />}
+      {modals.search && <SearchModal onClose={() => toggleModal("search")} />}
     </div>
   );
 }

--- a/client/src/components/layout/Sidebar.tsx
+++ b/client/src/components/layout/Sidebar.tsx
@@ -37,12 +37,12 @@ export default function SideBar({ handleRssModal, handleLoginModal, handleSideba
           홈
         </Button>
       )}
-      <Button variant="outline" className="overflow-hidden">
+      <div className="border border-input bg-background hover:bg-accent hover:text-accent-foreground h-[40px] overflow-hidden inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0">
         <SidebarProvider>
           <Chat />
           <OpenChat />
         </SidebarProvider>
-      </Button>
+      </div>
       <Button variant="default" className="w-full bg-primary" onClick={() => actionAndClose(handleRssModal)}>
         블로그 등록
       </Button>

--- a/client/src/components/layout/Sidebar.tsx
+++ b/client/src/components/layout/Sidebar.tsx
@@ -1,24 +1,49 @@
-import { Search } from "lucide-react";
+import { useNavigate } from "react-router-dom";
 
 import { Button } from "@/components/ui/button";
 
+import { Chat } from "../chat/Chat";
+import { OpenChat } from "../chat/ChatButton";
+import { SidebarProvider } from "../ui/sidebar";
+import { useTapStore } from "@/store/useTapStore";
+
 type SideBarType = {
   handleRssModal: () => void;
-  handleSearchModal: () => void;
   handleLoginModal: () => void;
+  handleSidebar: () => void;
 };
 
-export default function SideBar({ handleRssModal, handleSearchModal, handleLoginModal }: SideBarType) {
+export default function SideBar({ handleRssModal, handleLoginModal, handleSidebar }: SideBarType) {
+  const navigate = useNavigate();
+  const { tap, setTap } = useTapStore();
+  const actionAndClose = (fn: () => void) => {
+    fn();
+    handleSidebar();
+  };
   return (
     <div className="flex flex-col gap-4 p-4">
-      <Button onClick={handleSearchModal} variant="outline">
-        <Search />
-        검색
+      <Button onClick={() => navigate("/about")} variant="outline">
+        서비스 소개
       </Button>
-      <Button variant="outline" className="w-full" onClick={handleLoginModal}>
+      <Button variant="outline" className="w-full" onClick={() => actionAndClose(handleLoginModal)}>
         로그인
       </Button>
-      <Button variant="outline" className="w-full" onClick={handleRssModal}>
+      {tap === "main" ? (
+        <Button variant="outline" onClick={() => actionAndClose(() => setTap("chart"))}>
+          차트
+        </Button>
+      ) : (
+        <Button variant="outline" onClick={() => actionAndClose(() => setTap("main"))}>
+          홈
+        </Button>
+      )}
+      <Button variant="outline" className="overflow-hidden">
+        <SidebarProvider>
+          <Chat />
+          <OpenChat />
+        </SidebarProvider>
+      </Button>
+      <Button variant="default" className="w-full bg-primary" onClick={() => actionAndClose(handleRssModal)}>
         블로그 등록
       </Button>
     </div>

--- a/client/src/components/layout/navigation/DesktopNavigation.tsx
+++ b/client/src/components/layout/navigation/DesktopNavigation.tsx
@@ -1,0 +1,69 @@
+import { useNavigate } from "react-router-dom";
+
+import SideButton from "@/components/layout/SideButton";
+import SearchButton from "@/components/search/SearchButton";
+import { Button } from "@/components/ui/button";
+import {
+  NavigationMenu,
+  NavigationMenuItem,
+  NavigationMenuList,
+  NavigationMenuLink,
+  navigationMenuTriggerStyle,
+} from "@/components/ui/navigation-menu";
+
+import logo from "@/assets/logo-denamu-main.svg";
+
+export default function DesktopNavigation({
+  toggleModal,
+}: {
+  toggleModal: (modalType: "search" | "rss" | "login") => void;
+}) {
+  const navigate = useNavigate();
+
+  return (
+    <div className="h-20 items-center flex justify-between relative px-[20px]">
+      {/* 로고 */}
+      <button className="flex-shrink-0 relative z-50" onClick={() => location.reload()}>
+        <img className="h-14 w-auto cursor-pointer" src={logo} alt="Logo" />
+      </button>
+
+      {/* 검색 */}
+      <div className="absolute left-1/2 transform -translate-x-1/2 w-[25%] flex justify-center z-40">
+        <SearchButton handleSearchModal={() => toggleModal("search")} />
+      </div>
+      {/* 버튼 */}
+      <div className="flex items-center z-50">
+        <NavigationMenu>
+          <NavigationMenuList>
+            <NavigationMenuItem>
+              <SideButton />
+            </NavigationMenuItem>
+            <NavigationMenuItem>
+              <NavigationMenuLink
+                className={`${navigationMenuTriggerStyle()} hover:text-primary hover:bg-primary/10`}
+                onClick={() => navigate("/about")}
+                href="#"
+              >
+                서비스 소개
+              </NavigationMenuLink>
+            </NavigationMenuItem>
+            <NavigationMenuItem>
+              <NavigationMenuLink
+                className={`${navigationMenuTriggerStyle()} hover:text-primary hover:bg-primary/10`}
+                onClick={() => toggleModal("login")}
+                href="#"
+              >
+                로그인
+              </NavigationMenuLink>
+            </NavigationMenuItem>
+            <NavigationMenuItem>
+              <Button variant="default" onClick={() => toggleModal("rss")} className="bg-primary hover:bg-primary/90">
+                블로그 등록
+              </Button>
+            </NavigationMenuItem>
+          </NavigationMenuList>
+        </NavigationMenu>
+      </div>
+    </div>
+  );
+}

--- a/client/src/components/layout/navigation/MobileNavigation.tsx
+++ b/client/src/components/layout/navigation/MobileNavigation.tsx
@@ -1,0 +1,54 @@
+import { Menu } from "lucide-react";
+import { X } from "lucide-react";
+
+import SideBar from "@/components/layout/Sidebar";
+import SearchButton from "@/components/search/SearchButton";
+import { Button } from "@/components/ui/button";
+import { Sheet, SheetContent, SheetHeader, SheetTitle } from "@/components/ui/sheet";
+
+import logo from "@/assets/logo-denamu-title.svg";
+
+import { useSidebarStore } from "@/store/useSidebarStore";
+
+export default function MobileNavigation({
+  toggleModal,
+}: {
+  toggleModal: (modalType: "search" | "rss" | "login") => void;
+}) {
+  const { isOpen, setIsOpen } = useSidebarStore();
+  return (
+    <div className="h-20 items-center flex justify-between relative px-[10px]">
+      {/* 로고 */}
+      <button className="flex-shrink-0 relative z-50" onClick={() => location.reload()}>
+        <img className="h-14 w-auto cursor-pointer" src={logo} alt="Logo" />
+      </button>
+
+      {/* 검색 */}
+      <div className="absolute left-1/2 transform -translate-x-1/2 w-[50%] flex justify-center z-40">
+        <SearchButton handleSearchModal={() => toggleModal("search")} />
+      </div>
+      {/* 햄버거 버튼 */}
+      <Sheet open={isOpen}>
+        <Button variant="outline" size="icon" className="hover:border-primary hover:text-primary" onClick={setIsOpen}>
+          <Menu className="h-4 w-4" />
+        </Button>
+        <SheetContent className="w-full">
+          <SheetHeader>
+            <SheetTitle className="text-primary">메뉴</SheetTitle>
+            <Button
+              className="absolute right-2 top-0 rounded-sm opacity-70 bg-transparent text-black active:bg-transparent"
+              onClick={setIsOpen}
+            >
+              <X />
+            </Button>
+          </SheetHeader>
+          <SideBar
+            handleRssModal={() => toggleModal("rss")}
+            handleLoginModal={() => toggleModal("login")}
+            handleSidebar={setIsOpen}
+          />
+        </SheetContent>
+      </Sheet>
+    </div>
+  );
+}

--- a/client/src/components/layout/navigation/MobileNavigation.tsx
+++ b/client/src/components/layout/navigation/MobileNavigation.tsx
@@ -1,5 +1,4 @@
-import { Menu } from "lucide-react";
-import { X } from "lucide-react";
+import { Menu, X } from "lucide-react";
 
 import SideBar from "@/components/layout/Sidebar";
 import SearchButton from "@/components/search/SearchButton";

--- a/client/src/components/search/SearchButton.tsx
+++ b/client/src/components/search/SearchButton.tsx
@@ -15,7 +15,7 @@ export default function SearchButton({ handleSearchModal }: { handleSearchModal:
                    items-center 
                    hover:bg-primary/5 
                    max-w-[400px]
-                   
+                   hover:bg-seconary
                    "
       onClick={handleSearchModal}
     >

--- a/client/src/components/search/searchPages/SearchPages.tsx
+++ b/client/src/components/search/searchPages/SearchPages.tsx
@@ -31,7 +31,7 @@ export default function SearchPages({ totalPages }: { totalPages: number }) {
 
   return (
     <Pagination className="flex gap-4 absolute bottom-0">
-      <PaginationPrevious onClick={() => handlePage("prev")} className="border-none min-w-[100px]" />
+      <PaginationPrevious onClick={() => handlePage("prev")} className="border-none" />
 
       <PaginationContent>
         {page > 2 && <PaginationEllipsis />}
@@ -45,7 +45,7 @@ export default function SearchPages({ totalPages }: { totalPages: number }) {
         {page < totalPages - 2 && <PaginationEllipsis />}
       </PaginationContent>
 
-      <PaginationNext onClick={() => handlePage("next")} className="border-none min-w-[100px]" />
+      <PaginationNext onClick={() => handlePage("next")} className="border-none" />
     </Pagination>
   );
 }

--- a/client/src/components/ui/pagination.tsx
+++ b/client/src/components/ui/pagination.tsx
@@ -1,8 +1,10 @@
-import * as React from "react"
-import { ChevronLeft, ChevronRight, MoreHorizontal } from "lucide-react"
+import * as React from "react";
 
-import { cn } from "@/lib/utils"
-import { ButtonProps, buttonVariants } from "@/components/ui/button"
+import { ChevronLeft, ChevronRight, MoreHorizontal } from "lucide-react";
+
+import { ButtonProps, buttonVariants } from "@/components/ui/button";
+
+import { cn } from "@/lib/utils";
 
 const Pagination = ({ className, ...props }: React.ComponentProps<"nav">) => (
   <nav
@@ -11,40 +13,27 @@ const Pagination = ({ className, ...props }: React.ComponentProps<"nav">) => (
     className={cn("mx-auto flex w-full justify-center", className)}
     {...props}
   />
-)
-Pagination.displayName = "Pagination"
+);
+Pagination.displayName = "Pagination";
 
-const PaginationContent = React.forwardRef<
-  HTMLUListElement,
-  React.ComponentProps<"ul">
->(({ className, ...props }, ref) => (
-  <ul
-    ref={ref}
-    className={cn("flex flex-row items-center gap-1", className)}
-    {...props}
-  />
-))
-PaginationContent.displayName = "PaginationContent"
+const PaginationContent = React.forwardRef<HTMLUListElement, React.ComponentProps<"ul">>(
+  ({ className, ...props }, ref) => (
+    <ul ref={ref} className={cn("flex flex-row items-center gap-1", className)} {...props} />
+  )
+);
+PaginationContent.displayName = "PaginationContent";
 
-const PaginationItem = React.forwardRef<
-  HTMLLIElement,
-  React.ComponentProps<"li">
->(({ className, ...props }, ref) => (
+const PaginationItem = React.forwardRef<HTMLLIElement, React.ComponentProps<"li">>(({ className, ...props }, ref) => (
   <li ref={ref} className={cn("", className)} {...props} />
-))
-PaginationItem.displayName = "PaginationItem"
+));
+PaginationItem.displayName = "PaginationItem";
 
 type PaginationLinkProps = {
-  isActive?: boolean
+  isActive?: boolean;
 } & Pick<ButtonProps, "size"> &
-  React.ComponentProps<"a">
+  React.ComponentProps<"a">;
 
-const PaginationLink = ({
-  className,
-  isActive,
-  size = "icon",
-  ...props
-}: PaginationLinkProps) => (
+const PaginationLink = ({ className, isActive, size = "icon", ...props }: PaginationLinkProps) => (
   <a
     aria-current={isActive ? "page" : undefined}
     className={cn(
@@ -56,55 +45,30 @@ const PaginationLink = ({
     )}
     {...props}
   />
-)
-PaginationLink.displayName = "PaginationLink"
+);
+PaginationLink.displayName = "PaginationLink";
 
-const PaginationPrevious = ({
-  className,
-  ...props
-}: React.ComponentProps<typeof PaginationLink>) => (
-  <PaginationLink
-    aria-label="Go to previous page"
-    size="default"
-    className={cn("gap-1 pl-2.5", className)}
-    {...props}
-  >
+const PaginationPrevious = ({ className, ...props }: React.ComponentProps<typeof PaginationLink>) => (
+  <PaginationLink aria-label="Go to previous page" size="default" className={cn("gap-1 pl-2.5", className)} {...props}>
     <ChevronLeft className="h-4 w-4" />
-    <span>Previous</span>
   </PaginationLink>
-)
-PaginationPrevious.displayName = "PaginationPrevious"
+);
+PaginationPrevious.displayName = "PaginationPrevious";
 
-const PaginationNext = ({
-  className,
-  ...props
-}: React.ComponentProps<typeof PaginationLink>) => (
-  <PaginationLink
-    aria-label="Go to next page"
-    size="default"
-    className={cn("gap-1 pr-2.5", className)}
-    {...props}
-  >
-    <span>Next</span>
+const PaginationNext = ({ className, ...props }: React.ComponentProps<typeof PaginationLink>) => (
+  <PaginationLink aria-label="Go to next page" size="default" className={cn("gap-1 pr-2.5", className)} {...props}>
     <ChevronRight className="h-4 w-4" />
   </PaginationLink>
-)
-PaginationNext.displayName = "PaginationNext"
+);
+PaginationNext.displayName = "PaginationNext";
 
-const PaginationEllipsis = ({
-  className,
-  ...props
-}: React.ComponentProps<"span">) => (
-  <span
-    aria-hidden
-    className={cn("flex h-9 w-9 items-center justify-center", className)}
-    {...props}
-  >
+const PaginationEllipsis = ({ className, ...props }: React.ComponentProps<"span">) => (
+  <span aria-hidden className={cn("flex h-9 w-9 items-center justify-center", className)} {...props}>
     <MoreHorizontal className="h-4 w-4" />
     <span className="sr-only">More pages</span>
   </span>
-)
-PaginationEllipsis.displayName = "PaginationEllipsis"
+);
+PaginationEllipsis.displayName = "PaginationEllipsis";
 
 export {
   Pagination,
@@ -114,4 +78,4 @@ export {
   PaginationPrevious,
   PaginationNext,
   PaginationEllipsis,
-}
+};

--- a/client/src/components/ui/sheet.tsx
+++ b/client/src/components/ui/sheet.tsx
@@ -55,7 +55,14 @@ const SheetContent = React.forwardRef<React.ElementRef<typeof SheetPrimitive.Con
   ({ side = "right", className, children, ...props }, ref) => (
     <SheetPortal>
       <SheetOverlay />
-      <SheetPrimitive.Content ref={ref} className={cn(sheetVariants({ side }), className)} {...props}>
+      <SheetPrimitive.Content
+        ref={ref}
+        className={cn(sheetVariants({ side }), className)}
+        {...props}
+        aria-describedby={undefined}
+      >
+        <SheetTitle></SheetTitle>
+
         {children}
       </SheetPrimitive.Content>
     </SheetPortal>

--- a/client/src/components/ui/sheet.tsx
+++ b/client/src/components/ui/sheet.tsx
@@ -1,17 +1,17 @@
-import * as React from "react"
-import * as SheetPrimitive from "@radix-ui/react-dialog"
-import { cva, type VariantProps } from "class-variance-authority"
-import { X } from "lucide-react"
+import * as React from "react";
 
-import { cn } from "@/lib/utils"
+import { cva, type VariantProps } from "class-variance-authority";
 
-const Sheet = SheetPrimitive.Root
+import { cn } from "@/lib/utils";
+import * as SheetPrimitive from "@radix-ui/react-dialog";
 
-const SheetTrigger = SheetPrimitive.Trigger
+const Sheet = SheetPrimitive.Root;
 
-const SheetClose = SheetPrimitive.Close
+const SheetTrigger = SheetPrimitive.Trigger;
 
-const SheetPortal = SheetPrimitive.Portal
+const SheetClose = SheetPrimitive.Close;
+
+const SheetPortal = SheetPrimitive.Portal;
 
 const SheetOverlay = React.forwardRef<
   React.ElementRef<typeof SheetPrimitive.Overlay>,
@@ -25,8 +25,8 @@ const SheetOverlay = React.forwardRef<
     {...props}
     ref={ref}
   />
-))
-SheetOverlay.displayName = SheetPrimitive.Overlay.displayName
+));
+SheetOverlay.displayName = SheetPrimitive.Overlay.displayName;
 
 const sheetVariants = cva(
   "fixed z-50 gap-4 bg-background p-6 shadow-lg transition ease-in-out data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:duration-300 data-[state=open]:duration-500",
@@ -45,84 +45,49 @@ const sheetVariants = cva(
       side: "right",
     },
   }
-)
+);
 
 interface SheetContentProps
   extends React.ComponentPropsWithoutRef<typeof SheetPrimitive.Content>,
     VariantProps<typeof sheetVariants> {}
 
-const SheetContent = React.forwardRef<
-  React.ElementRef<typeof SheetPrimitive.Content>,
-  SheetContentProps
->(({ side = "right", className, children, ...props }, ref) => (
-  <SheetPortal>
-    <SheetOverlay />
-    <SheetPrimitive.Content
-      ref={ref}
-      className={cn(sheetVariants({ side }), className)}
-      {...props}
-    >
-      {children}
-      <SheetPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-secondary">
-        <X className="h-4 w-4" />
-        <span className="sr-only">Close</span>
-      </SheetPrimitive.Close>
-    </SheetPrimitive.Content>
-  </SheetPortal>
-))
-SheetContent.displayName = SheetPrimitive.Content.displayName
+const SheetContent = React.forwardRef<React.ElementRef<typeof SheetPrimitive.Content>, SheetContentProps>(
+  ({ side = "right", className, children, ...props }, ref) => (
+    <SheetPortal>
+      <SheetOverlay />
+      <SheetPrimitive.Content ref={ref} className={cn(sheetVariants({ side }), className)} {...props}>
+        {children}
+      </SheetPrimitive.Content>
+    </SheetPortal>
+  )
+);
+SheetContent.displayName = SheetPrimitive.Content.displayName;
 
-const SheetHeader = ({
-  className,
-  ...props
-}: React.HTMLAttributes<HTMLDivElement>) => (
-  <div
-    className={cn(
-      "flex flex-col space-y-2 text-center sm:text-left",
-      className
-    )}
-    {...props}
-  />
-)
-SheetHeader.displayName = "SheetHeader"
+const SheetHeader = ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
+  <div className={cn("flex flex-col space-y-2 text-center sm:text-left", className)} {...props} />
+);
+SheetHeader.displayName = "SheetHeader";
 
-const SheetFooter = ({
-  className,
-  ...props
-}: React.HTMLAttributes<HTMLDivElement>) => (
-  <div
-    className={cn(
-      "flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2",
-      className
-    )}
-    {...props}
-  />
-)
-SheetFooter.displayName = "SheetFooter"
+const SheetFooter = ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
+  <div className={cn("flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2", className)} {...props} />
+);
+SheetFooter.displayName = "SheetFooter";
 
 const SheetTitle = React.forwardRef<
   React.ElementRef<typeof SheetPrimitive.Title>,
   React.ComponentPropsWithoutRef<typeof SheetPrimitive.Title>
 >(({ className, ...props }, ref) => (
-  <SheetPrimitive.Title
-    ref={ref}
-    className={cn("text-lg font-semibold text-foreground", className)}
-    {...props}
-  />
-))
-SheetTitle.displayName = SheetPrimitive.Title.displayName
+  <SheetPrimitive.Title ref={ref} className={cn("text-lg font-semibold text-foreground", className)} {...props} />
+));
+SheetTitle.displayName = SheetPrimitive.Title.displayName;
 
 const SheetDescription = React.forwardRef<
   React.ElementRef<typeof SheetPrimitive.Description>,
   React.ComponentPropsWithoutRef<typeof SheetPrimitive.Description>
 >(({ className, ...props }, ref) => (
-  <SheetPrimitive.Description
-    ref={ref}
-    className={cn("text-sm text-muted-foreground", className)}
-    {...props}
-  />
-))
-SheetDescription.displayName = SheetPrimitive.Description.displayName
+  <SheetPrimitive.Description ref={ref} className={cn("text-sm text-muted-foreground", className)} {...props} />
+));
+SheetDescription.displayName = SheetPrimitive.Description.displayName;
 
 export {
   Sheet,
@@ -135,4 +100,4 @@ export {
   SheetFooter,
   SheetTitle,
   SheetDescription,
-}
+};

--- a/client/src/components/ui/sidebar.tsx
+++ b/client/src/components/ui/sidebar.tsx
@@ -16,7 +16,7 @@ import { Slot } from "@radix-ui/react-slot";
 const SIDEBAR_COOKIE_NAME = "sidebar:state";
 const SIDEBAR_COOKIE_MAX_AGE = 60 * 60 * 24 * 7;
 const SIDEBAR_WIDTH = "450px";
-const SIDEBAR_WIDTH_MOBILE = "18rem";
+const SIDEBAR_WIDTH_MOBILE = "100%";
 const SIDEBAR_WIDTH_ICON = "3rem";
 const SIDEBAR_KEYBOARD_SHORTCUT = "q";
 
@@ -49,8 +49,19 @@ const SidebarProvider = React.forwardRef<
     onOpenChange?: (open: boolean) => void;
   }
 >(({ defaultOpen = true, open: openProp, onOpenChange: setOpenProp, className, style, children, ...props }, ref) => {
-  const isMobile = false;
+  const [isMobile, setIsMobile] = React.useState(false);
   const [openMobile, setOpenMobile] = React.useState(false);
+  React.useEffect(() => {
+    const checkMobile = () => {
+      setIsMobile(window.innerWidth <= 767);
+    };
+
+    checkMobile();
+
+    window.addEventListener("resize", checkMobile);
+
+    return () => window.removeEventListener("resize", checkMobile);
+  }, []);
 
   // This is the internal state of the sidebar.
   // We use openProp and setOpenProp for control from outside the component.
@@ -163,7 +174,7 @@ const Sidebar = React.forwardRef<
               "--sidebar-width": SIDEBAR_WIDTH_MOBILE,
             } as React.CSSProperties
           }
-          side={side}
+          side={"right"}
         >
           <div className="flex h-full w-full flex-col">{children}</div>
         </SheetContent>

--- a/client/src/hooks/common/useMediaQuery.ts
+++ b/client/src/hooks/common/useMediaQuery.ts
@@ -1,0 +1,19 @@
+import { useState, useEffect } from "react";
+
+export const useMediaQuery = (query: string): boolean => {
+  const [viewport, setViewport] = useState(false);
+  useEffect(() => {
+    const mediaQuery = window.matchMedia(query);
+    setViewport(mediaQuery.matches);
+    const eventListener = (e: MediaQueryListEvent) => {
+      setViewport(e.matches);
+    };
+    mediaQuery.addEventListener("change", eventListener);
+
+    return () => {
+      mediaQuery.removeEventListener("change", eventListener);
+    };
+  }, [query]);
+
+  return viewport;
+};

--- a/client/src/store/useSidebarStore.ts
+++ b/client/src/store/useSidebarStore.ts
@@ -1,0 +1,11 @@
+import { create } from "zustand";
+
+type SidebarState = {
+  isOpen: boolean;
+  setIsOpen: () => void;
+};
+
+export const useSidebarStore = create<SidebarState>((set) => ({
+  isOpen: false,
+  setIsOpen: () => set((state) => ({ isOpen: !state.isOpen })),
+}));


### PR DESCRIPTION
# 🔨 테스크

### useMediaQuery 구현

```
import { useState, useEffect } from "react";

export const useMediaQuery = (query: string): boolean => {
  const [viewport, setViewport] = useState(false);
  useEffect(() => {
    const mediaQuery = window.matchMedia(query);
    setViewport(mediaQuery.matches);
    const eventListener = (e: MediaQueryListEvent) => {
      setViewport(e.matches);
    };
    mediaQuery.addEventListener("change", eventListener);

    return () => {
      mediaQuery.removeEventListener("change", eventListener);
    };
  }, [query]);

  return viewport;
};

```
- 문자열로 입력받은 viewport의 크기를 useEffect를 이용해 확인해가면서 모바일인지 아닌지 판단하는 함수입니다.



# 📋 작업 내용

-   헤더 반응형
-   채팅 및 사이드바 반응형
-   검색시 페이지네이션 부분 반응형

# 📷 스크린 샷
- 모바일일 경우 헤더의 로고부분을 변경하고 사이드바가 나올 수 있는 햄버거버튼을 추가했습니다.
![image](https://github.com/user-attachments/assets/5c16bd96-a6a1-4e19-8788-cd9f25d7121d)

- 페이지네이션시 previous, next라는 글자로 버튼을 생성했었는데 모바일에서는 글자가 잘리는 문제가 발생해서 삭제시켰습니다.
![image](https://github.com/user-attachments/assets/af3fc1eb-75b2-452a-8ebb-97ddc818b0d5)

- 사이드바와 채팅 모두 화면을 꽉 채우게 변경시켰습니다.
![image](https://github.com/user-attachments/assets/9d3b90dd-f6e2-4425-ac5f-10de8eea1a73)
![image](https://github.com/user-attachments/assets/99d4ba5b-0814-46c6-8f4d-6eba6925edc8)


