### PR TITLE
♻️ refactor: 반응형 레이아웃 변경, 모바일 카드 디자인 수정

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -4,8 +4,11 @@ import { Routes, Route } from "react-router-dom";
 import LoadingPage from "@/pages/Loading.tsx";
 import NotFound from "@/pages/NotFound";
 
+import { useMediaQuery } from "@/hooks/common/useMediaQuery";
+
 import { denamuAscii } from "@/constants/denamuAscii.ts";
 
+import { useMediaStore } from "@/store/useMediaStore";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
 
@@ -16,9 +19,16 @@ const AboutService = lazy(() => import("@/pages/AboutService"));
 const queryClient = new QueryClient();
 
 export default function App() {
+  const setIsMobile = useMediaStore((state) => state.setIsMobile);
+  const isMobile = useMediaQuery("(max-width: 767px)");
+
   useEffect(() => {
     console.log(denamuAscii);
   }, []);
+
+  useEffect(() => {
+    setIsMobile(isMobile);
+  }, [isMobile]);
 
   return (
     <QueryClientProvider client={queryClient}>

--- a/client/src/components/common/Card/PostCard.tsx
+++ b/client/src/components/common/Card/PostCard.tsx
@@ -1,18 +1,24 @@
-import { Card } from "@/components/ui/card";
+import { Card, MCard } from "@/components/ui/card";
 
 import { usePostCardActions } from "@/hooks/common/usePostCardActions";
 
 import { PostCardContent } from "./PostCardContent";
 import { PostCardImage } from "./PostCardImage";
 import { cn } from "@/lib/utils";
-import { Post } from "@/types/post";
-
-interface PostCardProps {
-  post: Post;
-  className?: string;
-}
+import { useMediaStore } from "@/store/useMediaStore";
+import { PostCardProps } from "@/types/card";
 
 export const PostCard = ({ post, className }: PostCardProps) => {
+  const isMobile = useMediaStore((state) => state.isMobile);
+
+  return isMobile ? (
+    <MobileCard post={post} className={className} />
+  ) : (
+    <DesktopCard post={post} className={className} />
+  );
+};
+
+const DesktopCard = ({ post, className }: PostCardProps) => {
   const { handlePostClick } = usePostCardActions(post);
 
   return (
@@ -26,5 +32,18 @@ export const PostCard = ({ post, className }: PostCardProps) => {
       <PostCardImage thumbnail={post.thumbnail} alt={post.title} />
       <PostCardContent post={post} />
     </Card>
+  );
+};
+const MobileCard = ({ post, className }: PostCardProps) => {
+  const { handlePostClick } = usePostCardActions(post);
+
+  return (
+    <MCard
+      onClick={handlePostClick}
+      className={cn("aspect-[5/3] transition-all duration-300 flex flex-col gap-2", className)}
+    >
+      <PostCardImage thumbnail={post.thumbnail} alt={post.title} />
+      <PostCardContent post={post} />
+    </MCard>
   );
 };

--- a/client/src/components/common/Card/PostCardContent.tsx
+++ b/client/src/components/common/Card/PostCardContent.tsx
@@ -1,32 +1,66 @@
-import { useState } from "react";
-
 import { Avatar, AvatarFallback } from "@/components/ui/avatar";
 import { CardContent } from "@/components/ui/card";
 
 import { formatDate } from "@/utils/date";
 
+import { useMediaStore } from "@/store/useMediaStore";
 import { Post } from "@/types/post";
 
+const isValidPlatform = (platform: string): boolean => {
+  const validPlatforms = ["tistory", "velog", "medium"];
+  return validPlatforms.includes(platform);
+};
 interface PostCardContentProps {
   post: Post;
 }
 
 export const PostCardContent = ({ post }: PostCardContentProps) => {
-  const [isValidImage, setIsValidImage] = useState<boolean>(true);
+  const isMobile = useMediaStore((state) => state.isMobile);
+
+  return isMobile ? <MobileCardContent post={post} /> : <DesktopCardContent post={post} />;
+};
+
+const MobileCardContent = ({ post }: PostCardContentProps) => {
   const authorInitial = post.author?.charAt(0)?.toUpperCase() || "?";
-  const data = `https://denamu.site/files/${post.blogPlatform}-icon.svg`;
+
+  return (
+    <CardContent className="p-0">
+      <div className="flex items-center ml-4 mb-3 gap-3">
+        <Avatar className="h-8 w-8 ring-2 ring-background cursor-pointer">
+          {isValidPlatform(post.blogPlatform) ? (
+            <img
+              src={`https://denamu.site/files/${post.blogPlatform}-icon.svg`}
+              alt={post.author}
+              className="w-full h-full"
+            />
+          ) : (
+            <AvatarFallback className="text-xs bg-slate-200">{authorInitial}</AvatarFallback>
+          )}
+        </Avatar>
+        <p className="font-bold text-sm">{post.author}</p>
+      </div>
+      <div className="px-4 pb-4">
+        <p className="h-[48px] font-bold text-md group-hover:text-primary transition-colors line-clamp-2">
+          {post.title}
+        </p>
+        <p className="text-[12px] text-gray-400 pt-2">{formatDate(post.createdAt)}</p>
+      </div>
+    </CardContent>
+  );
+};
+
+const DesktopCardContent = ({ post }: PostCardContentProps) => {
+  const authorInitial = post.author?.charAt(0)?.toUpperCase() || "?";
+
   return (
     <CardContent className="p-0">
       <div className="relative -mt-6 ml-4 mb-3">
         <Avatar className="h-8 w-8 ring-2 ring-background cursor-pointer">
-          {isValidImage ? (
+          {isValidPlatform(post.blogPlatform) ? (
             <img
-              src={data}
+              src={`https://denamu.site/files/${post.blogPlatform}-icon.svg`}
               alt={post.author}
               className="w-full h-full"
-              onError={() => {
-                setIsValidImage(false);
-              }}
             />
           ) : (
             <AvatarFallback className="text-xs bg-slate-200">{authorInitial}</AvatarFallback>
@@ -43,3 +77,5 @@ export const PostCardContent = ({ post }: PostCardContentProps) => {
     </CardContent>
   );
 };
+
+export default PostCardContent;

--- a/client/src/components/common/Card/PostCardImage.tsx
+++ b/client/src/components/common/Card/PostCardImage.tsx
@@ -10,7 +10,7 @@ interface PostCardImageProps {
 export const PostCardImage = ({ thumbnail, alt }: PostCardImageProps) => {
   return (
     <div
-      className="h-[120px] relative bg-muted flex items-center justify-center overflow-hidden rounded-t-xl"
+      className="h-full md:h-[120px] relative bg-muted flex items-center justify-center overflow-hidden rounded md:rounded-t-xl"
       data-testid="image-container"
     >
       {thumbnail ? (

--- a/client/src/components/common/SectionHeader.tsx
+++ b/client/src/components/common/SectionHeader.tsx
@@ -9,7 +9,7 @@ interface SectionHeaderProps {
 
 export const SectionHeader = ({ icon: Icon, text, iconColor, description }: SectionHeaderProps) => {
   return (
-    <div className="flex items-center gap-2">
+    <div className="flex items-center gap-2 p-4 md:p-0">
       {Icon && (
         <div>
           <Icon className={`w-5 h-5 ${iconColor}`} />

--- a/client/src/components/layout/Header.tsx
+++ b/client/src/components/layout/Header.tsx
@@ -7,14 +7,15 @@ import SearchModal from "@/components/search/SearchModal";
 
 import { useCustomToast } from "@/hooks/common/useCustomToast.ts";
 import { useKeyboardShortcut } from "@/hooks/common/useKeyboardShortcut";
-import { useMediaQuery } from "@/hooks/common/useMediaQuery";
 
 import { TOAST_MESSAGES } from "@/constants/messages";
+
+import { useMediaStore } from "@/store/useMediaStore";
 
 export default function Header() {
   const [modals, setModals] = useState({ search: false, rss: false, login: false, chat: false });
   const { toast } = useCustomToast();
-  const isMobile = useMediaQuery("(max-width: 767px)");
+  const isMobile = useMediaStore((state) => state.isMobile);
   const toggleModal = (modalType: "search" | "rss" | "login" | "chat") => {
     if (modalType === "login") {
       toast(TOAST_MESSAGES.SERVICE_NOT_PREPARED);

--- a/client/src/components/layout/Layout.tsx
+++ b/client/src/components/layout/Layout.tsx
@@ -10,7 +10,7 @@ export default function Layout({ children }: LayoutProps) {
     <>
       <Header />
       <main className="w-full">
-        <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">{children}</div>
+        <div className="mx-auto max-w-7xl px-0 md:px-8">{children}</div>
       </main>
       <Toaster />
     </>

--- a/client/src/components/sections/AnimatedPostGrid.tsx
+++ b/client/src/components/sections/AnimatedPostGrid.tsx
@@ -14,7 +14,7 @@ const AnimatedPostGrid = ({ posts }: AnimatedPostGridProps) => {
   const { hasPosition } = usePositionTracking(posts);
 
   return (
-    <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-6 relative">
+    <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 md:gap-6 relative">
       <AnimatePresence initial={false}>
         {posts.map((post) => {
           return (

--- a/client/src/components/sections/LatestSection.tsx
+++ b/client/src/components/sections/LatestSection.tsx
@@ -36,9 +36,9 @@ export default function LatestSection() {
   }, [fetchNextPage, hasNextPage, isFetchingNextPage]);
 
   return (
-    <section className="flex flex-col p-4 min-h-[300px]">
+    <section className="flex flex-col md:p-4 min-h-[300px]">
       <SectionHeader icon={Rss} text="최신 포스트" description="최근에 작성된 포스트" iconColor="text-orange-500" />
-      <div className="flex-1 mt-4 p-4 rounded-lg">
+      <div className="flex-1 mt-4 md:p-6 rounded-lg">
         {isLoading ? (
           <PostGridSkeleton count={8} />
         ) : (

--- a/client/src/components/sections/MainContent.tsx
+++ b/client/src/components/sections/MainContent.tsx
@@ -1,10 +1,14 @@
 import LatestSection from "@/components/sections/LatestSection";
 import TrandingSection from "@/components/sections/TrendingSection";
 
+import { useMediaStore } from "@/store/useMediaStore";
+
 export default function MainContent() {
+  const isMobile = useMediaStore((state) => state.isMobile);
   return (
-    <div className="flex flex-col p-8 gap-8">
+    <div className="flex flex-col px-4 md:p-8 md:gap-8">
       <TrandingSection />
+      {isMobile && <hr className="border-t-2 border-dotted border-gray-500 my-4 " />}
       <LatestSection />
     </div>
   );

--- a/client/src/components/sections/TrendingSection.tsx
+++ b/client/src/components/sections/TrendingSection.tsx
@@ -6,21 +6,22 @@ import AnimatedPostGrid from "@/components/sections/AnimatedPostGrid";
 
 import { useTrendingPosts } from "@/hooks/queries/useTrendingPosts";
 
+import { useMediaStore } from "@/store/useMediaStore";
+
 export default function TrendingSection() {
   const { posts, isLoading } = useTrendingPosts();
-
+  const isMobile = useMediaStore((state) => state.isMobile);
+  const sectionStyle = isMobile ? undefined : { boxShadow: "0 0 15px rgba(0, 0, 0, 0.1)" };
   return (
-    <section className="flex flex-col p-4 min-h-[300px]">
+    <section className="flex flex-col md:p-4 min-h-[300px]">
       <SectionHeader
         icon={TrendingUp}
         text="트렌딩 포스트"
         description="오늘 가장 인기있는 포스트"
         iconColor="text-red-500"
       />
-      <div
-        className="flex-1 mt-4 p-6 bg-white rounded-2xl transition-all duration-300"
-        style={{ boxShadow: "0 0 15px rgba(0, 0, 0, 0.1)" }}
-      >
+
+      <div className="flex-1 md:mt-4 md:p-6 bg-white rounded-2xl transition-all duration-300" style={sectionStyle}>
         {isLoading || !posts.length ? <PostGridSkeleton count={4} /> : <AnimatedPostGrid posts={posts} />}
       </div>
     </section>

--- a/client/src/components/ui/card.tsx
+++ b/client/src/components/ui/card.tsx
@@ -7,6 +7,11 @@ const Card = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElemen
 ));
 Card.displayName = "Card";
 
+const MCard = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(({ className, ...props }, ref) => (
+  <div ref={ref} className={cn("bg-card text-card-foreground", className)} {...props} />
+));
+MCard.displayName = "MobileCard";
+
 const CardHeader = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
   ({ className, ...props }, ref) => (
     <div ref={ref} className={cn("flex flex-col space-y-1.5 p-6", className)} {...props} />
@@ -38,4 +43,4 @@ const CardFooter = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDiv
 );
 CardFooter.displayName = "CardFooter";
 
-export { Card, CardHeader, CardFooter, CardTitle, CardDescription, CardContent };
+export { Card, MCard, CardHeader, CardFooter, CardTitle, CardDescription, CardContent };

--- a/client/src/store/useMediaStore.ts
+++ b/client/src/store/useMediaStore.ts
@@ -1,0 +1,13 @@
+import { create } from "zustand";
+
+type MediaType = {
+  isMobile: boolean;
+  setIsMobile: (value: boolean) => void;
+};
+
+export const useMediaStore = create<MediaType>((set) => ({
+  isMobile: false,
+  setIsMobile: (value) => {
+    set({ isMobile: value });
+  },
+}));

--- a/client/src/types/card.ts
+++ b/client/src/types/card.ts
@@ -1,0 +1,6 @@
+import { Post } from "@/types/post";
+
+export interface PostCardProps {
+  post: Post;
+  className?: string;
+}

--- a/client/src/types/post.ts
+++ b/client/src/types/post.ts
@@ -9,7 +9,7 @@ export interface Post {
   authorImageUrl?: string;
   tags?: string[];
   likes?: number;
-  blogPlatform?: string;
+  blogPlatform: string;
 }
 
 export interface LatestPostsApiResponse {


### PR DESCRIPTION
# 🔨 테스크

- 반응형 레이아웃 변경
- 모바일 카드 디자인 수정

# 📋 작업 내용

- 반응형 레이아웃 변경
  - useMediaQuery 훅 생성 후 해당 훅으로 viewport의 크기를 판단하여 모바일인지 데스크탑인지 판단하도록 작성했습니다.
  - useMediaStore  스토어를 생성하여 각 컴포넌트 별로 뷰포트의 크기를 계산하는게 아니라 app.tsx가 마운트 될 때 검사를 진 
    행하도록 구현했습니다.
  - layout과 pages폴더의 스타일을 수정하여 768px 미만일 때만 구조가 변경되도록 수정했습니다.

- 모바일 카드 디자인 수정
  - 이전에 피그마로 보여드린 디자인대로 수정해봤습니다.
 

# 📷 스크린 샷

![image](https://github.com/user-attachments/assets/c17603b4-fb24-46ec-943d-7914317f1309)

