### PR TITLE
📦 chore: 프론트엔드 Docker 이미지 작성 개발 환경, 로컬 환경 Docker Compose (2)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,10 @@ loadtest/FE_Report
 loadtest/BE_Report.html
 loadtest/FE_Report.html
 
+### HTTPS ###
+private.key
+certificate.crt
+
 ### VisualStudioCode ###
 .vscode/*
 !.vscode/settings.json

--- a/client/.dockerignore
+++ b/client/.dockerignore
@@ -1,0 +1,3 @@
+node_modules
+.git
+dist

--- a/client/.gitignore
+++ b/client/.gitignore
@@ -11,6 +11,7 @@ node_modules
 dist
 dist-ssr
 *.local
+!Dockerfile.local
 
 # Editor directories and files
 .vscode/*

--- a/client/Dockerfile
+++ b/client/Dockerfile
@@ -1,0 +1,28 @@
+FROM node:22-alpine AS builder
+
+# 작업 디렉토리 생성 및 설정
+WORKDIR /var/client
+
+# 필요한 파일만 복사하여 캐시 활용
+COPY package*.json ./
+
+# 의존성 설치
+RUN npm ci
+
+# Runtime
+# 실제 앱을 실행할 최종 이미지
+FROM node:22-alpine
+
+# 작업 디렉토리 설정
+WORKDIR /var/client
+
+# 최종 애플리케이션 코드만 복사
+COPY . .
+
+# 빌드된 node_modules만 복사
+COPY --from=builder /var/client/node_modules ./node_modules
+
+EXPOSE 5173
+
+# 실행 명령
+CMD ["npm", "run", "dev", "--", "--host", "0.0.0.0"]

--- a/client/Dockerfile
+++ b/client/Dockerfile
@@ -1,7 +1,7 @@
 FROM node:22-alpine AS builder
 
 # 작업 디렉토리 생성 및 설정
-WORKDIR /var/client
+WORKDIR /var/web05-Denamu/client
 
 # 필요한 파일만 복사하여 캐시 활용
 COPY package*.json ./
@@ -14,13 +14,13 @@ RUN npm ci
 FROM node:22-alpine
 
 # 작업 디렉토리 설정
-WORKDIR /var/client
+WORKDIR /var/web05-Denamu/client
 
 # 최종 애플리케이션 코드만 복사
 COPY . .
 
 # 빌드된 node_modules만 복사
-COPY --from=builder /var/client/node_modules ./node_modules
+COPY --from=builder /var/web05-Denamu/client/node_modules ./node_modules
 
 EXPOSE 5173
 

--- a/client/docker/Dockerfile.dev
+++ b/client/docker/Dockerfile.dev
@@ -4,7 +4,7 @@ FROM node:22-alpine AS builder
 WORKDIR /var/web05-Denamu/client
 
 # 필요한 파일만 복사하여 캐시 활용
-COPY package*.json ./
+COPY ../package*.json ./
 
 # 의존성 설치
 RUN npm ci
@@ -17,7 +17,7 @@ FROM node:22-alpine
 WORKDIR /var/web05-Denamu/client
 
 # 최종 애플리케이션 코드만 복사
-COPY . .
+COPY .. .
 
 # 빌드된 node_modules만 복사
 COPY --from=builder /var/web05-Denamu/client/node_modules ./node_modules

--- a/client/docker/Dockerfile.local
+++ b/client/docker/Dockerfile.local
@@ -15,4 +15,7 @@ WORKDIR /var/web05-Denamu/client
 COPY --from=builder /var/web05-Denamu/client/dist /var/web05-Denamu/client/dist
 COPY ../../static /var/web05-Denamu/static
 
-CMD ["nginx","-g","daemon off;"]
+COPY ../../nginx//scripts/generate_cert.sh /etc/nginx/scripts/generate_cert.sh
+COPY ../../nginx/nginx.conf /etc/nginx/nginx.conf
+
+CMD ["/bin/sh","-c","/etc/nginx/scripts/generate_cert.sh && nginx -g 'daemon off;'"];

--- a/client/docker/Dockerfile.local
+++ b/client/docker/Dockerfile.local
@@ -13,9 +13,9 @@ FROM nginx:1.18.0-alpine
 WORKDIR /var/web05-Denamu/client
 
 COPY --from=builder /var/web05-Denamu/client/dist /var/web05-Denamu/client/dist
-COPY ../../static /var/web05-Denamu/static
+RUN cp ../../static /var/web05-Denamu/static
 
-COPY ../../nginx/scripts/generate_cert.sh /etc/nginx/scripts/generate_cert.sh
-COPY ../../nginx/nginx.conf /etc/nginx/nginx.conf
+RUN cp ../../nginx/scripts/generate_cert.sh /etc/nginx/scripts/generate_cert.sh
+RUN cp ../../nginx/nginx.conf /etc/nginx/nginx.conf
 
 CMD ["/bin/sh","-c","/etc/nginx/scripts/generate_cert.sh && nginx -g 'daemon off;'"];

--- a/client/docker/Dockerfile.local
+++ b/client/docker/Dockerfile.local
@@ -1,21 +1,23 @@
-FROM node:22.11.0-alpine AS builder
+FROM node:22-alpine AS builder
 
 WORKDIR /var/web05-Denamu/client
 
-COPY .. .
+COPY ./client .
 
 RUN npm ci
 
 RUN npm run build
 
-FROM nginx:1.18.0-alpine
+FROM nginx:1.18.0
 
 WORKDIR /var/web05-Denamu/client
 
 COPY --from=builder /var/web05-Denamu/client/dist /var/web05-Denamu/client/dist
-RUN cp ../../static /var/web05-Denamu/static
+COPY ../../static /var/web05-Denamu/static
 
-RUN cp ../../nginx/scripts/generate_cert.sh /etc/nginx/scripts/generate_cert.sh
-RUN cp ../../nginx/nginx.conf /etc/nginx/nginx.conf
+COPY ../../nginx/scripts /etc/nginx/scripts
+COPY ../../nginx/nginx.conf /etc/nginx/nginx.conf
 
-CMD ["/bin/sh","-c","/etc/nginx/scripts/generate_cert.sh && nginx -g 'daemon off;'"];
+RUN sh "/etc/nginx/scripts/generate_cert.sh"
+
+CMD ["nginx","-g","daemon off;"]

--- a/client/docker/Dockerfile.local
+++ b/client/docker/Dockerfile.local
@@ -1,0 +1,18 @@
+FROM node:22.11.0-alpine AS builder
+
+WORKDIR /var/web05-Denamu/client
+
+COPY .. .
+
+RUN npm ci
+
+RUN npm run build
+
+FROM nginx:1.18.0-alpine
+
+WORKDIR /var/web05-Denamu/client
+
+COPY --from=builder /var/web05-Denamu/client/dist /var/web05-Denamu/client/dist
+COPY ../../static /var/web05-Denamu/static
+
+CMD ["nginx","-g","daemon off;"]

--- a/client/docker/Dockerfile.local
+++ b/client/docker/Dockerfile.local
@@ -15,7 +15,7 @@ WORKDIR /var/web05-Denamu/client
 COPY --from=builder /var/web05-Denamu/client/dist /var/web05-Denamu/client/dist
 COPY ../../static /var/web05-Denamu/static
 
-COPY ../../nginx//scripts/generate_cert.sh /etc/nginx/scripts/generate_cert.sh
+COPY ../../nginx/scripts/generate_cert.sh /etc/nginx/scripts/generate_cert.sh
 COPY ../../nginx/nginx.conf /etc/nginx/nginx.conf
 
 CMD ["/bin/sh","-c","/etc/nginx/scripts/generate_cert.sh && nginx -g 'daemon off;'"];

--- a/client/vite.config.ts
+++ b/client/vite.config.ts
@@ -48,4 +48,9 @@ export default defineConfig({
       },
     },
   },
+  server: {
+    watch: {
+      usePolling: true,
+    },
+  },
 });

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -1,0 +1,143 @@
+user www-data;
+worker_processes auto;
+pid /run/nginx.pid;
+include /etc/nginx/modules-enabled/*.conf;
+
+events {
+	worker_connections 768;
+	# multi_accept on;
+}
+
+http {
+	##
+	# Basic Settings
+	##
+
+	sendfile on;
+	tcp_nopush on;
+	types_hash_max_size 2048;
+	# server_tokens off;
+
+	# server_names_hash_bucket_size 64;
+	# server_name_in_redirect off;
+
+	include /etc/nginx/mime.types;
+	default_type application/octet-stream;
+
+	##
+	# SSL Settings
+	##
+
+	ssl_protocols TLSv1 TLSv1.1 TLSv1.2 TLSv1.3; # Dropping SSLv3, ref: POODLE
+	ssl_prefer_server_ciphers on;
+
+	##
+	# Logging Settings
+	##
+	log_format custom_spring_style '[$time_local] INFO [PID:$pid] --- [Thread:$connection] $remote_addr : $request_method "$request_uri" $status ($request_time sec) referer="$http_referer" agent="$http_user_agent" bytes=$bytes_sent req_length=$request_length';
+
+	access_log /var/log/nginx/access.log custom_spring_style;
+	error_log /var/log/nginx/error.log error;
+
+	##
+	# Gzip Settings
+	##
+
+	gzip on;
+
+	# gzip_vary on;
+	# gzip_proxied any;
+	# gzip_comp_level 6;
+	# gzip_buffers 16 8k;
+	# gzip_http_version 1.1;
+	# gzip_types text/plain text/css application/json application/javascript text/xml application/xml application/xml+rss text/javascript;
+
+	##
+	# Virtual Host Configs
+	##
+
+	# include /etc/nginx/conf.d/*.conf;
+	# include /etc/nginx/sites-enabled/*;
+	# HTTP로 들어오는 요청을 HTTPS로 Redirect
+	server {
+		listen 80;
+		server_name localhost;
+
+		return 301 https://$host$request_uri;
+	}
+
+	# HTTPS로 들어온 요청에 대한 처리 진행
+	server {
+		listen 443 ssl;
+		server_name localhost;
+
+		ssl_certificate /etc/nginx/certs/certificate.crt;
+		ssl_certificate_key /etc/nginx/certs/private.key;
+
+		# 정적 파일 서빙 - FE 빌드 파일
+		location / {
+			root /var/web05-Denamu/client/dist;
+			index index.html;
+			try_files $uri /index.html;
+		}
+
+		# 정적 파일 서빙
+		location /files {
+			alias /var/web05-Denamu/static/;
+			try_files $uri $uri/ =404;
+		}
+
+		# API 요청을 NestJS로 프록시
+		location /api {
+			proxy_pass http://nestjs-app:8080;
+			proxy_http_version 1.1;
+			proxy_set_header Upgrade $http_upgrade;
+			proxy_set_header Connection 'upgrade';
+			proxy_set_header Host $host;
+			proxy_cache_bypass $http_upgrade;
+			proxy_read_timeout 3600s;
+
+			proxy_set_header X-Real-IP $remote_addr;  # X-Real-IP 헤더로 실제 IP 전달
+			proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;  # X-Forwarded-For 헤더로 실제 IP 전달
+			proxy_set_header X-Forwarded-Proto $scheme; # 클라이언트의 프로토콜 전달
+		}
+
+		# WebSocket 요청 프록시
+		location /chat {
+			proxy_pass http://nestjs-app:8080;
+			proxy_http_version 1.1;
+			proxy_set_header Upgrade $http_upgrade;
+			proxy_set_header Connection "upgrade";
+			proxy_set_header Host $host;
+			proxy_cache_bypass $http_upgrade;
+			proxy_read_timeout 3600s;
+			proxy_send_timeout 3600s;
+
+			proxy_set_header X-Real-IP $remote_addr;  # X-Real-IP 헤더로 실제 IP 전달
+			proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;  # X-Forwarded-For 헤더로 실제 IP 전달
+			proxy_set_header X-Forwarded-Proto $scheme; # 클라이언트의 프로토콜 전달
+		}
+	}
+}
+
+
+#mail {
+#	# See sample authentication script at:
+#	# http://wiki.nginx.org/ImapAuthenticateWithApachePhpScript
+#
+#	# auth_http localhost/auth.php;
+#	# pop3_capabilities "TOP" "USER";
+#	# imap_capabilities "IMAP4rev1" "UIDPLUS";
+#
+#	server {
+#		listen     localhost:110;
+#		protocol   pop3;
+#		proxy      on;
+#	}
+#
+#	server {
+#		listen     localhost:143;
+#		protocol   imap;
+#		proxy      on;
+#	}
+#}

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -89,7 +89,7 @@ http {
 
 		# API 요청을 NestJS로 프록시
 		location /api {
-			proxy_pass http://nestjs-app:8080;
+			proxy_pass http://app:8080;
 			proxy_http_version 1.1;
 			proxy_set_header Upgrade $http_upgrade;
 			proxy_set_header Connection 'upgrade';
@@ -104,7 +104,7 @@ http {
 
 		# WebSocket 요청 프록시
 		location /chat {
-			proxy_pass http://nestjs-app:8080;
+			proxy_pass http://app:8080;
 			proxy_http_version 1.1;
 			proxy_set_header Upgrade $http_upgrade;
 			proxy_set_header Connection "upgrade";

--- a/nginx/scripts/generate_cert.sh
+++ b/nginx/scripts/generate_cert.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+
+CERT_DIR="/etc/nginx/certs"
+mkdir -p "$CERT_DIR"
+
+# 인증서가 없을 때만 생성
+if [ ! -f "$CERT_DIR/private.key" ] || [ ! -f "$CERT_DIR/certificate.crt" ]; then
+  echo "Generating self-signed SSL certificate..."
+  openssl req -x509 -newkey rsa:4096 -keyout "$CERT_DIR/private.key" -out "$CERT_DIR/certificate.crt" -days 365 -nodes -subj "/CN=localhost"
+  echo "SSL certificate generated!"
+else
+  echo "SSL certificate already exists. Skipping generation."
+fi
+
+exec "$@"


### PR DESCRIPTION
# 🔨 테스크

### 이전 PR 보러 가기

- 1편: https://github.com/boostcampwm-2024/refactor-web05-Denamu/pull/35

### Docker 환경 분리

- 우리 팀에 필요한 Docker 환경은 무엇이 있을까?
1. 개발 환경
2. 로컬 환경 (포트폴리오)
3. 운영 환경

개발 환경 먼저 설정을 하려 했으나, 백엔드측 feed-crawler에서 환경 변수 문제로 인해 Docker CI/CD도 함께 공부하면서 진행해야 할듯 하여 일단은 프론트엔드 코드 먼저 이미지로 변경 하는 PR 작성

### NGINX Conf를 동기화 하는 방법은?
Host OS와 NGINX Conf를 동기화하기 위해서는 Volume을 이용해야 하는데, 단일 Dockerfile에서 HostOS와 볼륨을 연결하는 방법은 없고 Docker Compose를 사용해야 한다. Docker Compose PR은 서버까지 다 끝내고 올리도록 하겠습니다.

### 빌드 크기 최적화
#### 개선전 Dockerfile
- 빌드 시간
![최적화 전 빌드 시간](https://github.com/user-attachments/assets/64546497-42b2-4708-aab4-8f4b7e09068b)
- 용량
![최적화 전 용량](https://github.com/user-attachments/assets/63dc1f0e-ace0-4eb8-8d6e-a92e9444cdd8)

docker build client -t denamu-front
빌드 15초, 용량 1.51 GB
```dockerfile
FROM node:22
WORKDIR /var/client
COPY . .

RUN npm ci

CMD ["npm", "run", "dev", "--", "--host", "0.0.0.0"]
```

#### 베이스 이미지 교체
일반 리눅스 배포판보다 크기가 작은 alpine 버전을 사용하도록 변경하여 베이스 이미지 크기 줄이기
빌드 15초, 용량: 572 MB
- 빌드 시간
![빌드 시간](https://github.com/user-attachments/assets/2bcf3d46-095e-46ee-9347-8e255342fc36)
- 용량
![빌드 용량](https://github.com/user-attachments/assets/7dab77b9-4d0e-4f83-a84e-527aa0e4f3db)

```dockerfile
FROM node:22-alpine
WORKDIR /var/client
COPY . .

RUN npm ci

CMD ["npm", "run", "dev", "--", "--host", "0.0.0.0"]
```

#### 멀티 스테이지 빌드
의존성 설치 같은 필요한 행위를 각 스테이지로 분리시켜 캐시가 쌓이지 않도록 하여 이미지 크기를 최소화하는 방법
빌드 13초, 용량 478.21MB
- 빌드 시간
![빌드 시간](https://github.com/user-attachments/assets/34b63007-ad08-4f79-a110-20047a8565e7)
- 용량
![빌드 용량](https://github.com/user-attachments/assets/d1c4a038-ddd8-4b71-a55c-6f856dbd3e61)
```dockerfile
# 빌드를 위한 첫 번째 단계
FROM node:22-alpine AS builder

# 작업 디렉토리 생성 및 설정
WORKDIR /var/client

# 필요한 파일만 복사하여 캐시 활용
COPY package*.json ./

# 의존성 설치
RUN npm ci

# Runtime
# 실제 앱을 실행할 최종 이미지
FROM node:22-alpine

# 작업 디렉토리 설정
WORKDIR /var/client

# 최종 애플리케이션 코드만 복사
COPY . .

# 빌드된 node_modules만 복사
COPY --from=builder /var/client/node_modules ./node_modules

# 실행 명령
CMD ["npm", "run", "dev", "--", "--host", "0.0.0.0"]
```

### 빌드 컨텍스트 외부 파일 가져오기
COPY로 수행할 경우 바로 상위 디렉터리까지만 빌드 컨텍스트가 도달한다.
하지만, static과 nginx는 상위/상위 디렉터리로 가야 해서 빌드 컨텍스트가 도달하지 않는 문제가 있었다.
```dockerfile
# 변경 전
COPY ../../static /var/web05-Denamu/static

COPY ../../nginx/scripts/generate_cert.sh /etc/nginx/scripts/generate_cert.sh
COPY ../../nginx/nginx.conf /etc/nginx/nginx.conf

# 변경 후
RUN cp ../../static /var/web05-Denamu/static

RUN cp ../../nginx/scripts/generate_cert.sh /etc/nginx/scripts/generate_cert.sh
RUN cp ../../nginx/nginx.conf /etc/nginx/nginx.conf
```

### 프론트엔드 Vite Watch 안 되는 문제 발생
- 사유:
WSL2의 고질병으로 HostOS에서 코드를 바꿨을 때, 컨테이너에서 코드 변경을 인식하지 못 해 Vite가 Hot Reload가 안 되는 문제가 발생
- 해결 방법: 
vite.config를 수정
```
server: {
	watch: {
		usePolling: true
	}
}
```

위 설정 같은 경우 기존에는 파일 변경 시에만 Vite가 HMR를 하는 방식이었지만 Polling으로 바꾸면 주기적으로 파일 변경을 확인해야 하기 때문에 노트북 같은 경우 배터리 소모량이 증가할 수 있다.
다만, 이 옵션을 안 켜면 컨테이너 내에서 Ctrl+S 를 통해 적용해야 한다.

# 📋 작업 내용
- 프론트엔드 코드 -> Docker 이미지로 변경
   - 개발 환경: Client
   - 로컬 환경(포트폴리오): NGINX + Client
-  NGINX Conf 파일 구성