### PR TITLE
📦 chore: Feed Crawler Docker 이미지 작성 개발 환경, 로컬 환경 Docker Compose (3)

### DIFF
--- a/feed-crawler/.dockerignore
+++ b/feed-crawler/.dockerignore
@@ -2,3 +2,4 @@ dist
 node_modules
 .git
 logs
+test/coverage

--- a/feed-crawler/.dockerignore
+++ b/feed-crawler/.dockerignore
@@ -1,0 +1,4 @@
+dist
+node_modules
+.git
+logs

--- a/feed-crawler/docker/Dockerfile.dev
+++ b/feed-crawler/docker/Dockerfile.dev
@@ -16,6 +16,6 @@ COPY --from=builder /var/web05-Denamu/feed-crawler/node_modules ./node_modules
 
 RUN touch /var/log/feed-crawler.log
 
-RUN echo "* * * * * cd /var/web05-Denamu/feed-crawler && npm run build && npm start &>> /var/log/feed-crawler.log" >> /etc/crontabs/root
+RUN echo "*/30 * * * * cd /var/web05-Denamu/feed-crawler && npm run start:dev >> /var/log/feed-crawler.log 2>&1" >> /etc/crontabs/root
 
-CMD ["sh", "-c", "tail -f /var/log/feed-crawler.log"]
+CMD ["sh", "-c", "crond && tail -f /var/log/feed-crawler.log"]

--- a/feed-crawler/docker/Dockerfile.dev
+++ b/feed-crawler/docker/Dockerfile.dev
@@ -1,0 +1,21 @@
+FROM node:22-alpine AS builder
+
+WORKDIR /var/web05-Denamu/feed-crawler
+
+COPY ../package*.json ./
+
+RUN npm ci
+
+FROM node:22-alpine
+
+WORKDIR /var/web05-Denamu/feed-crawler
+
+COPY .. .
+
+COPY --from=builder /var/web05-Denamu/feed-crawler/node_modules ./node_modules
+
+RUN touch /var/log/feed-crawler.log
+
+RUN echo "* * * * * cd /var/web05-Denamu/feed-crawler && npm run build && npm start &>> /var/log/feed-crawler.log" >> /etc/crontabs/root
+
+CMD ["sh", "-c", "tail -f /var/log/feed-crawler.log"]

--- a/feed-crawler/docker/Dockerfile.local
+++ b/feed-crawler/docker/Dockerfile.local
@@ -2,11 +2,7 @@ FROM node:22-alpine AS builder
 
 WORKDIR /var/web05-Denamu/feed-crawler
 
-COPY ../package*.json .
-
-COPY ../src .
-
-COPY ../tsconfig.json .
+COPY .. .
 
 RUN npm ci
 
@@ -17,8 +13,9 @@ FROM node:22-alpine
 WORKDIR /var/web05-Denamu/feed-crawler
 
 COPY --from=builder /var/web05-Denamu/feed-crawler/dist ./dist
-
+COPY --from=builder /var/web05-Denamu/feed-crawler/package.json .
 COPY --from=builder /var/web05-Denamu/feed-crawler/node_modules ./node_modules
+COPY --from=builder /var/web05-Denamu/feed-crawler/env ./env
 
 RUN touch /var/log/feed-crawler.log
 

--- a/feed-crawler/docker/Dockerfile.local
+++ b/feed-crawler/docker/Dockerfile.local
@@ -1,0 +1,25 @@
+FROM node:22-alpine AS builder
+
+WORKDIR /var/web05-Denamu/feed-crawler
+
+COPY ../package*.json .
+
+COPY ../src .
+
+RUN npm ci
+
+RUN npm run build
+
+FROM node:22-alpine
+
+WORKDIR /var/web05-Denamu/feed-crawler
+
+COPY --from=builder /var/web05-Denamu/feed-crawler/dist ./dist
+
+COPY --from=builder /var/web05-Denamu/feed-crawler/node_modules ./node_modules
+
+RUN touch /var/log/feed-crawler.log
+
+RUN echo "*/30 * * * * cd /var/web05-Denamu/feed-crawler && npm run start &>> /var/log/feed-crawler.log" > /etc/crontabs/root
+
+CMD ["sh", "-c", "tail -f /var/log/feed-crawler.log"]

--- a/feed-crawler/docker/Dockerfile.local
+++ b/feed-crawler/docker/Dockerfile.local
@@ -22,6 +22,6 @@ COPY --from=builder /var/web05-Denamu/feed-crawler/node_modules ./node_modules
 
 RUN touch /var/log/feed-crawler.log
 
-RUN echo "*/30 * * * * cd /var/web05-Denamu/feed-crawler && npm run start &>> /var/log/feed-crawler.log" > /etc/crontabs/root
+RUN echo "*/30 * * * * cd /var/web05-Denamu/feed-crawler && npm run start >> /var/log/feed-crawler.log 2>&1" > /etc/crontabs/root
 
-CMD ["sh", "-c", "tail -f /var/log/feed-crawler.log"]
+CMD ["sh", "-c", "crond && tail -f /var/log/feed-crawler.log"]

--- a/feed-crawler/docker/Dockerfile.local
+++ b/feed-crawler/docker/Dockerfile.local
@@ -6,6 +6,8 @@ COPY ../package*.json .
 
 COPY ../src .
 
+COPY ../tsconfig.json .
+
 RUN npm ci
 
 RUN npm run build


### PR DESCRIPTION
# 🔨 테스크
### 이전 PR 보러 가기

- 1편: https://github.com/boostcampwm-2024/refactor-web05-Denamu/pull/35
- 2편: https://github.com/boostcampwm-2024/refactor-web05-Denamu/pull/34

### Docker Container 내부 크론

-   크론은 데몬 프로세스라 포어그라운드로 돌아가는 프로세스가 아니라서 Docker에서 인식을 하지 못 하고 컨테이너가 꺼지는 문제가 발생했다.
- 크론은 데몬 프로세스이기에 출력 결과가 터미널로 넘어오지 않는 문제가 있었다.
- 중간 파일을 두어, tail 을 통해 파일 변화를 탐지하고 그 결과를 출력하도록 변경했다.

### alpine 버전의 리다이렉트 문법
alpine 버전은 여타 다른 리눅스 배포판과 다르게 Bash가 아닌 ash를 사용한다. 그래서 표준 오류와 표준 출력을 함께 쓰는 리다이렉트 문법인 `&>>` 은 사용할 수 없다.
표준 에러와 표준 출력을 2&>1 로 적어줘야 올바르게 파일로 출력 내용이 리다이렉트 되었다.

# 📋 작업 내용
- Feed Crawler Dev 이미지 Dockerfile 작성 
-   Feed Crawler Local 이미지 Dockerfile 작성
