### PR TITLE
✨ feat: Feature Feed-Crawler에서 클로바스튜디오 API를 사용하도록 적용

### DIFF
--- a/feed-crawler/src/clova.service.ts
+++ b/feed-crawler/src/clova.service.ts
@@ -1,0 +1,98 @@
+import { injectable } from "tsyringe";
+
+@injectable()
+export class ClovaService {
+  private readonly apiKey: string;
+  private readonly baseUrl: string;
+  private readonly requestId: string;
+
+  constructor() {
+    this.apiKey = process.env.CLOVA_STUDIO_TEST_API_KEY;
+    this.baseUrl = process.env.CLOVA_STUDIO_TEST_API_URL;
+    this.requestId = process.env.X_NCP_CLOVA_STUDIO_REQUEST_ID;
+  }
+
+  async postFeedContent(text: string): Promise<string> {
+    try {
+      const response = await fetch(this.baseUrl, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${this.apiKey}`,
+          "X-NCP-CLOVASTUDIO-REQUEST-ID": `${this.requestId}`,
+          Accept: "text/event-stream",
+        },
+        body: JSON.stringify({
+          messages: [
+            {
+              role: "system",
+              content:
+                "당신의 유일한 역할은 제공된 텍스트를 분석하여 관련된 기술 스택과 도구를 식별하는 것입니다.\\n\\nALLOWED_TAGS: [Vue, React, HTML, Shadcn, SCSS, JavaScript, TypeScript, Spring Boot, Fast API, Nest.js, MySQL, MariaDB, Oracle DB, PostgresQL, Network, Linux, Window, Mac, Docker, kubernates]\\n\\n절대적인 규칙:\\n1. ALLOWED_TAGS 리스트의 키워드만 사용 가능\\n2. 리스트에 없는 기술 용어는 무시\\n3. 문맥상 실제로 해당 기술을 다루는 경우만 태그 선정\\n4. 단순 언급이나 비교 대상으로 등장하는 경우는 제외\\n5. 연관도는 해당 기술의 중요도/비중을 0-100% 사이로 표현\\n6. 같은 기술은 ALLOWED_TAGS의 형식으로 고쳐주세요. 예를 들어 자바, java, JAVA, Java는 모두 Java로 표현합니다.\\n7.연관도가 60%보다 떨어지면 출력하지 않아도 됩니다.\\n\\n출력 형식:\\n키워드1/연관도%, 키워드2/연관도%, ...\\n\\n이 작업만 수행하세요. 다른 설명이나 분석은 하지 마세요.",
+            },
+            {
+              role: "user",
+              content: text,
+            },
+          ],
+          topP: 0.8,
+          topK: 0,
+          maxTokens: 1500,
+          temperature: 0.5,
+          repeatPenalty: 5.0,
+          stopBefore: [],
+          includeAiFilters: true,
+        }),
+      });
+
+      if (!response.ok) {
+        throw new Error(`HTTP error! status: ${response.status}`);
+      }
+
+      if (!response.body) {
+        throw new Error("Response body is null");
+      }
+
+      const reader = response.body.getReader();
+      let tagResult = "";
+      let buffer = "";
+
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+
+        const chunk = new TextDecoder().decode(value);
+
+        buffer += chunk;
+
+        const events = buffer.split("\n\n");
+        buffer = events.pop() || "";
+
+        for (const event of events) {
+          const lines = event.split("\n");
+          let eventData = "";
+
+          for (const line of lines) {
+            if (line.startsWith("data:")) {
+              eventData += line.slice(5).trim();
+            }
+          }
+
+          if (eventData) {
+            try {
+              const parsedData = JSON.parse(eventData);
+              if (parsedData.message.content) {
+                tagResult = parsedData.message.content;
+              }
+            } catch (e) {
+              continue;
+            }
+          }
+        }
+      }
+
+      return tagResult;
+    } catch (error) {
+      throw error;
+    }
+  }
+}

--- a/feed-crawler/src/common/types.ts
+++ b/feed-crawler/src/common/types.ts
@@ -2,6 +2,8 @@ export interface RawFeed {
   title: string;
   link: string;
   pubDate: string;
+  description?: string;
+  "content:encoded"?: string;
 }
 
 export interface RssObj {
@@ -20,4 +22,6 @@ export interface FeedDetail {
   title: string;
   link: string;
   imageUrl: string;
+  content: string;
+  tag?: string[];
 }

--- a/feed-crawler/src/container.ts
+++ b/feed-crawler/src/container.ts
@@ -1,15 +1,37 @@
 import { container } from "tsyringe";
 import { DatabaseConnection } from "./types/database-connection";
 import { DEPENDENCY_SYMBOLS } from "./types/dependency-symbols";
-import {MySQLConnection} from "./common/mysql-access";
-import {RssRepository} from "./repository/rss.repository";
-import {FeedRepository} from "./repository/feed.repository";
-import {RedisConnection} from "./common/redis-access";
+import { MySQLConnection } from "./common/mysql-access";
+import { RssRepository } from "./repository/rss.repository";
+import { FeedRepository } from "./repository/feed.repository";
+import { RedisConnection } from "./common/redis-access";
+import { ClovaService } from "./clova.service";
+import { FeedTagRepository } from "./repository/feed-tag.repository";
 
-container.registerSingleton<DatabaseConnection>(DEPENDENCY_SYMBOLS.DatabaseConnection, MySQLConnection);
-container.registerSingleton<RedisConnection>(DEPENDENCY_SYMBOLS.RedisConnection, RedisConnection);
+container.registerSingleton<DatabaseConnection>(
+  DEPENDENCY_SYMBOLS.DatabaseConnection,
+  MySQLConnection,
+);
+container.registerSingleton<RedisConnection>(
+  DEPENDENCY_SYMBOLS.RedisConnection,
+  RedisConnection,
+);
 
-container.registerSingleton<RssRepository>(DEPENDENCY_SYMBOLS.RssRepository, RssRepository);
-container.registerSingleton<FeedRepository>(DEPENDENCY_SYMBOLS.FeedRepository, FeedRepository);
+container.registerSingleton<RssRepository>(
+  DEPENDENCY_SYMBOLS.RssRepository,
+  RssRepository,
+);
+container.registerSingleton<FeedRepository>(
+  DEPENDENCY_SYMBOLS.FeedRepository,
+  FeedRepository,
+);
 
+container.registerSingleton<ClovaService>(
+  DEPENDENCY_SYMBOLS.ClovaService,
+  ClovaService,
+);
+container.registerSingleton<FeedTagRepository>(
+  DEPENDENCY_SYMBOLS.FeedTagRepository,
+  FeedTagRepository,
+);
 export { container };

--- a/feed-crawler/src/main.ts
+++ b/feed-crawler/src/main.ts
@@ -9,7 +9,6 @@ import { DatabaseConnection } from "./types/database-connection";
 import { ClovaService } from "./clova.service";
 import { FeedTagRepository } from "./repository/feed-tag.repository";
 
-
 async function main() {
   logger.info("==========작업 시작==========");
   const startTime = Date.now();
@@ -28,12 +27,6 @@ async function main() {
   );
   const feedTagRepository = container.resolve<FeedTagRepository>(
     DEPENDENCY_SYMBOLS.FeedTagRepository,
-  );
-  const feedRepository = container.resolve<FeedRepository>(
-    DEPENDENCY_SYMBOLS.FeedRepository
-  );
-  const dbConnection = container.resolve<DatabaseConnection>(
-    DEPENDENCY_SYMBOLS.DatabaseConnection
   );
 
   const feedCrawler = new FeedCrawler(

--- a/feed-crawler/src/main.ts
+++ b/feed-crawler/src/main.ts
@@ -2,20 +2,39 @@ import "reflect-metadata";
 import logger from "./common/logger.js";
 import { FeedCrawler } from "./feed-crawler.js";
 import { container } from "./container";
-import {RssRepository} from "./repository/rss.repository";
-import {FeedRepository} from "./repository/feed.repository";
-import {DEPENDENCY_SYMBOLS} from "./types/dependency-symbols";
-import {DatabaseConnection} from "./types/database-connection";
+import { RssRepository } from "./repository/rss.repository";
+import { FeedRepository } from "./repository/feed.repository";
+import { DEPENDENCY_SYMBOLS } from "./types/dependency-symbols";
+import { DatabaseConnection } from "./types/database-connection";
+import { ClovaService } from "./clova.service";
+import { FeedTagRepository } from "./repository/feed-tag.repository";
 
 async function main() {
   logger.info("==========작업 시작==========");
   const startTime = Date.now();
 
-  const rssRepository = container.resolve<RssRepository>(DEPENDENCY_SYMBOLS.RssRepository);
-  const feedRepository = container.resolve<FeedRepository>(DEPENDENCY_SYMBOLS.FeedRepository);
-  const dbConnection = container.resolve<DatabaseConnection>(DEPENDENCY_SYMBOLS.DatabaseConnection);
+  const rssRepository = container.resolve<RssRepository>(
+    DEPENDENCY_SYMBOLS.RssRepository,
+  );
+  const feedRepository = container.resolve<FeedRepository>(
+    DEPENDENCY_SYMBOLS.FeedRepository,
+  );
+  const dbConnection = container.resolve<DatabaseConnection>(
+    DEPENDENCY_SYMBOLS.DatabaseConnection,
+  );
+  const clovaService = container.resolve<ClovaService>(
+    DEPENDENCY_SYMBOLS.ClovaService,
+  );
+  const feedTagRepository = container.resolve<FeedTagRepository>(
+    DEPENDENCY_SYMBOLS.FeedTagRepository,
+  );
 
-  const feedCrawler = new FeedCrawler(rssRepository, feedRepository);
+  const feedCrawler = new FeedCrawler(
+    rssRepository,
+    feedRepository,
+    clovaService,
+    feedTagRepository,
+  );
   await feedCrawler.start();
 
   const endTime = Date.now();

--- a/feed-crawler/src/repository/feed-tag.repository.ts
+++ b/feed-crawler/src/repository/feed-tag.repository.ts
@@ -15,14 +15,15 @@ export class FeedTagRepository {
     tagNames: string[]
   ): Promise<void> {
     try {
+      if (tagNames.length === 0) {
+        return;
+      }
+
       const tagIdsQuery = "SELECT id FROM tag WHERE name IN (?)";
       const tagIds = await this.dbConnection.executeQuery(tagIdsQuery, [
         tagNames,
       ]);
 
-      if (tagNames.length === 0) {
-        return;
-      }
       const insertPromises = tagIds.map(({ id: tagId }) => {
         const query = "INSERT INTO feed_tag (feed_id, tag_id) VALUES (?, ?)";
         return this.dbConnection.executeQuery(query, [feedId, tagId]);

--- a/feed-crawler/src/repository/feed-tag.repository.ts
+++ b/feed-crawler/src/repository/feed-tag.repository.ts
@@ -1,0 +1,38 @@
+import { inject, injectable } from "tsyringe";
+import { DEPENDENCY_SYMBOLS } from "../types/dependency-symbols";
+import { DatabaseConnection } from "../types/database-connection";
+import logger from "../common/logger";
+
+@injectable()
+export class FeedTagRepository {
+  constructor(
+    @inject(DEPENDENCY_SYMBOLS.DatabaseConnection)
+    private readonly dbConnection: DatabaseConnection
+  ) {}
+
+  public async insertFeedTags(
+    feedId: number,
+    tagNames: string[]
+  ): Promise<void> {
+    try {
+      const tagIdsQuery = "SELECT id FROM tag WHERE name IN (?)";
+      const tagIds = await this.dbConnection.executeQuery(tagIdsQuery, [
+        tagNames,
+      ]);
+
+      if (tagNames.length === 0) {
+        return;
+      }
+      const insertPromises = tagIds.map(({ id: tagId }) => {
+        const query = "INSERT INTO feed_tag (feed_id, tag_id) VALUES (?, ?)";
+        return this.dbConnection.executeQuery(query, [feedId, tagId]);
+      });
+
+      await Promise.all(insertPromises);
+
+      logger.info(`Feed ${feedId}의 태그 저장 완료: ${JSON.stringify(tagIds)}`);
+    } catch (error) {
+      throw error;
+    }
+  }
+}

--- a/feed-crawler/src/types/dependency-symbols.ts
+++ b/feed-crawler/src/types/dependency-symbols.ts
@@ -1,6 +1,10 @@
+import { FeedTagRepository } from "../repository/feed-tag.repository";
+
 export const DEPENDENCY_SYMBOLS = {
-    DatabaseConnection: Symbol.for("DatabaseConnection"),
-    RssRepository: Symbol.for("RssRepository"),
-    FeedRepository: Symbol.for("FeedRepository"),
-    RedisConnection: Symbol.for("RedisConnection"),
-}
+  DatabaseConnection: Symbol.for("DatabaseConnection"),
+  RssRepository: Symbol.for("RssRepository"),
+  FeedRepository: Symbol.for("FeedRepository"),
+  RedisConnection: Symbol.for("RedisConnection"),
+  ClovaService: Symbol.for("ClovaService"),
+  FeedTagRepository: Symbol.for("FeedTagRepository"),
+};

--- a/feed-crawler/test/feed-crawling.e2e-spec.ts
+++ b/feed-crawler/test/feed-crawling.e2e-spec.ts
@@ -9,6 +9,8 @@ describe("feed crawling e2e-test", () => {
     feedCrawler = new FeedCrawler(
       testContext.rssRepository,
       testContext.feedRepository,
+      testContext.clovaService,
+      testContext.feedTagRepository,
     );
   });
 

--- a/feed-crawler/test/setup/testContext.setup.ts
+++ b/feed-crawler/test/setup/testContext.setup.ts
@@ -7,6 +7,8 @@ import { RssRepository } from "../../src/repository/rss.repository";
 import { FeedRepository } from "../../src/repository/feed.repository";
 import { container } from "tsyringe";
 import { DependencyContainer } from "tsyringe";
+import { ClovaService } from "../../src/clova.service";
+import { FeedTagRepository } from "../../src/repository/feed-tag.repository";
 
 export interface TestContext {
   container: DependencyContainer;
@@ -14,6 +16,8 @@ export interface TestContext {
   feedRepository: FeedRepository;
   dbConnection: DatabaseConnection;
   redisConnection: RedisConnection;
+  clovaService: ClovaService;
+  feedTagRepository: FeedTagRepository;
 }
 
 declare global {
@@ -49,9 +53,19 @@ export function setupTestContainer(): TestContext {
       RssRepository,
     );
 
+    testContainer.registerSingleton<ClovaService>(
+      DEPENDENCY_SYMBOLS.ClovaService,
+      ClovaService,
+    );
+
     testContainer.registerSingleton<FeedRepository>(
       DEPENDENCY_SYMBOLS.FeedRepository,
       FeedRepository,
+    );
+
+    testContainer.registerSingleton<FeedTagRepository>(
+      DEPENDENCY_SYMBOLS.FeedTagRepository,
+      FeedTagRepository,
     );
 
     global.testContext = {
@@ -67,6 +81,12 @@ export function setupTestContainer(): TestContext {
       ),
       redisConnection: testContainer.resolve<RedisConnection>(
         DEPENDENCY_SYMBOLS.RedisConnection,
+      ),
+      clovaService: testContainer.resolve<ClovaService>(
+        DEPENDENCY_SYMBOLS.ClovaService,
+      ),
+      feedTagRepository: testContainer.resolve<FeedTagRepository>(
+        DEPENDENCY_SYMBOLS.FeedTagRepository,
       ),
     };
   }


### PR DESCRIPTION
# 🔨 테스크

### ID 이슈
Feed-Crawler 동작에서 feed를 가져오고 먼저 태그를 생성하면 안되는 이유가 있었다.
ID가 Auto_Increment로 생성되기에 먼저 데이터 삽입이 끝나고 feed_tag에 데이터를 삽입해야 했다.
처음에는 삽입 후 다시 SELECT 문으로 데이터를 가져와야 한다고 생각해서, Feed 테이블에 JSON 타입의 Tag 컬럼을 생성했다.
하지만 제 1정규형을 위반하면 좋지 않다는 민석님의 조언을 듣고 다시 생각해보니, 이미 iserFeeds 메서드에서 ID를 가져오는 로직이 있는 것이 떠올랐다.
MySQL 쿼리 실행 후 해당하는 ID를 반환해주는 데, 그 값을 그대로 이용하면 끝인 문제였다.

### 태그 분석 시 데이터를 읽지 못하는 이슈
태그를 ReadableStream으로 받아오는데, 한 번씩 JSON.parse() 메서드를 실행할 수 없다는 에러가 발생했다.
학습 스프린트 2차 미션 때가 생각났는데, 그 때도 이미지 파일이 크면 나뉘어 전송되었던 것으로 기억한다.
이번에도 그런 류의 문제로 JSON 데이터가 다 전송되지 않았는데 파싱을 시도한 것으로 예측했다.
그래서 학습 스프린트 2차 미션처럼 버퍼를 도입하고 완전히 전송 끝난 이벤트만 처리할 수 있도록 기다리는 방법을 사용했다.

# 📋 작업 내용

- 클로바 스튜디오 API를 Feed-Crawler에서 호출할 수 있도록 ClovaService 구현
- 게시글을 읽어오면 그 글을 바탕으로 태그를 분석 후 feed_tag 테이블에 저장
  - 쓸데없는 토큰 사용을 방지하기 위해 글 본문의 xml 태그를 삭제하는 로직 추가 

# 📷 스크린 샷

- 데이터베이스 확인
![image](https://github.com/user-attachments/assets/6867478c-eaf1-42c4-9719-13a2fd614d98)
![image](https://github.com/user-attachments/assets/6687913c-32cc-4f27-b175-07760231688f)
![image](https://github.com/user-attachments/assets/714b89bc-58ae-411c-82df-cf2bd57930fa)

