### PR TITLE
✨ feat: Tag-Map Entity 추가

### DIFF
--- a/server/src/feed/entity/feed.entity.ts
+++ b/server/src/feed/entity/feed.entity.ts
@@ -61,7 +61,7 @@ export class Feed extends BaseEntity {
   tag: string[];
 
   @Column({
-    type: 'mediumtext',
+    type: 'text',
     nullable: true,
   })
   summary: string;

--- a/server/src/feed/entity/feed.entity.ts
+++ b/server/src/feed/entity/feed.entity.ts
@@ -6,11 +6,13 @@ import {
   Index,
   JoinColumn,
   ManyToOne,
+  OneToMany,
   PrimaryGeneratedColumn,
   ViewColumn,
   ViewEntity,
 } from 'typeorm';
 import { RssAccept } from '../../rss/entity/rss.entity';
+import { TagMap } from './tag-map.entity';
 
 @Entity({ name: 'feed' })
 export class Feed extends BaseEntity {
@@ -54,6 +56,15 @@ export class Feed extends BaseEntity {
     name: 'blog_id',
   })
   blog: RssAccept;
+
+  @OneToMany(() => TagMap, (tag) => tag.feed)
+  tag: string[];
+
+  @Column({
+    type: 'mediumtext',
+    nullable: true,
+  })
+  summary: string;
 }
 
 @ViewEntity({

--- a/server/src/feed/entity/tag-map.entity.ts
+++ b/server/src/feed/entity/tag-map.entity.ts
@@ -1,0 +1,26 @@
+import {
+  BaseEntity,
+  Entity,
+  JoinColumn,
+  ManyToOne,
+  PrimaryColumn,
+} from 'typeorm';
+import { Feed } from './feed.entity';
+
+@Entity({ name: 'tag_map' })
+export class TagMap extends BaseEntity {
+  @PrimaryColumn({ name: 'feed_id', type: 'number' })
+  @ManyToOne(() => Feed, (feed) => feed.tag, {
+    nullable: true,
+    onDelete: 'CASCADE',
+  })
+  @JoinColumn({ name: 'feed_id' })
+  feed: Feed;
+
+  @PrimaryColumn({
+    name: 'tag',
+    length: 50,
+    nullable: false,
+  })
+  tag: string;
+}

--- a/server/src/feed/entity/tag-map.entity.ts
+++ b/server/src/feed/entity/tag-map.entity.ts
@@ -11,7 +11,7 @@ import { Feed } from './feed.entity';
 export class TagMap extends BaseEntity {
   @PrimaryColumn({ name: 'feed_id', type: 'number' })
   @ManyToOne(() => Feed, (feed) => feed.tag, {
-    nullable: true,
+    nullable: false,
     onDelete: 'CASCADE',
   })
   @JoinColumn({ name: 'feed_id' })

--- a/server/src/feed/module/feed.module.ts
+++ b/server/src/feed/module/feed.module.ts
@@ -8,10 +8,17 @@ import {
 import { ScheduleModule } from '@nestjs/schedule';
 import { EventEmitterModule } from '@nestjs/event-emitter';
 import { FeedScheduler } from '../scheduler/feed.scheduler';
+import { TagMapRepository } from '../repository/tag-map.repository';
 
 @Module({
   imports: [ScheduleModule.forRoot(), EventEmitterModule.forRoot()],
   controllers: [FeedController],
-  providers: [FeedService, FeedRepository, FeedViewRepository, FeedScheduler],
+  providers: [
+    FeedService,
+    FeedRepository,
+    FeedViewRepository,
+    TagMapRepository,
+    FeedScheduler,
+  ],
 })
 export class FeedModule {}

--- a/server/src/feed/repository/tag-map.repository.ts
+++ b/server/src/feed/repository/tag-map.repository.ts
@@ -1,0 +1,10 @@
+import { DataSource, Repository } from 'typeorm';
+import { Injectable } from '@nestjs/common';
+import { TagMap } from '../entity/tag-map.entity';
+
+@Injectable()
+export class TagMapRepository extends Repository<TagMap> {
+  constructor(private dataSource: DataSource) {
+    super(TagMap, dataSource.createEntityManager());
+  }
+}


### PR DESCRIPTION
# 🔨 테스크

### Tag 테이블을 사용하지 않아도 되는가?
명기님께서 의견을 주셨고 저와 명기님, 민석님이 함께 합의를 보았습니다.
클로바 스튜디오 API를 사용할 때는 원하지 않던 데이터가 함께 추출되어 저희가 원하는 태그만 사용할 수 있도록 Tag 테이블을 생성했습니다. 
그러나 Claude API로 변경 후에는 개발자가 제시한 프롬프트 내에서 데이터가 추출되어 Tag 테이블이 필요하지 않다는 의견이 있었습니다.  
Tag 데이터가 갱신되지 않고 읽는 용으로만 사용되어, AI 모델의 정확성이 높다면 프롬프트를 통해서만 관리할 수 있습니다.
굳이 테이블을 하나 더 관리하고 Join 연산을 추가할 필요가 없었고 납득이 되어 이대로 진행했습니다.

# 📋 작업 내용

- TagMap 엔티티 생성
- Feed 엔티티에 Tag 배열과 summary 추가

# 📷 스크린 샷
![image](https://github.com/user-attachments/assets/d6b79edc-4149-41dd-afe6-221806d2aceb)

![image](https://github.com/user-attachments/assets/8ae11b7b-658e-44b5-b96f-bb9434c2500f)


