### PR TITLE
🐛 fix: 요약 글 제목 및 bold체로 출력되게 구현

### DIFF
--- a/feed-crawler/src/common/constant.ts
+++ b/feed-crawler/src/common/constant.ts
@@ -43,21 +43,28 @@ export const PROMPT_CONTENT = `[System]
 You need to assign tags and provide a summary of the content.
 The input format is XML.
 Remove the XML tags and analyze the content.
+
 The language of the content is Korean.
 Analyze the content and assign 0 to 5 relevant tags.
 Only assign tags that have at least 90% relevance to the content.
+
 If no tag has 90% relevance or more, return:
 tags: { }
+
 The summary of the content should be returned in the summary field.
 The summary must be in Korean.
 When summarizing, make it engaging and intriguing so that a first-time reader would want to click on the original post.
+
 If possible, organize the summary using Markdown format.
+The first line of the summary must be the title and should be displayed in **bold**.
+
 Output Format:
 You must respond with raw JSON only, without any code blocks or backticks. 
 The output should be in JSON format only, containing tags, relevance, and summary.
 Do not wrap the response in code blocks.
 Do not provide any additional explanations.
 Do not use any markdown formatting for the JSON output itself.
+
 The response should look exactly like this, without any surrounding characters:
 {
   "tags": {
@@ -67,6 +74,7 @@ The response should look exactly like this, without any surrounding characters:
   },
   "summary": summary<string>
 }
+
 ## Do not assign any tags that are not in the predefined tag list.
 Strictly follow this rule.
 Tag List:

--- a/server/src/rss/service/ai-tag-summary.service.ts
+++ b/server/src/rss/service/ai-tag-summary.service.ts
@@ -46,6 +46,7 @@ The summary must be in Korean.
 When summarizing, make it engaging and intriguing so that a first-time reader would want to click on the original post.
 
 If possible, organize the summary using Markdown format.
+The first line of the summary must be the title and should be displayed in **bold**.
 
 Output Format:
 You must respond with raw JSON only, without any code blocks or backticks. 


### PR DESCRIPTION
# 🔨 테스크

### 프롬프트

-  요약 첫 줄이 h1 태그인 경우가 있고, bold인 경우가 있고, 일반적인 경우가 있어서 불편함 가독성 떨어짐!
- Enginnering이라는 태그 범위가 너무 넓어서 앵간한 게시글에 싹 다 Enginnering 태그가 붙음. Engineering을 Software Engineering으로 바꾸기에는 너무 김. 그래서 없애기로 결정!

# 📋 작업 내용

-   프롬프트 정확성 추가. 요약 글 제목에는 반드시 bold체 + 요약 제목을 적도록 프롬프트 추가
