### PR TITLE
🐛 fix: engineering 태그 너무 포괄적 범주라 삭제

### DIFF
--- a/feed-crawler/src/common/constant.ts
+++ b/feed-crawler/src/common/constant.ts
@@ -22,7 +22,6 @@ export const ALLOWED_TAGS = [
   "OS",
   "Algorithm",
   "Infra",
-  "Engineering",
   "TypeScript",
   "JavaScript",
   "Java",

--- a/server/src/rss/service/ai-tag-summary.service.ts
+++ b/server/src/rss/service/ai-tag-summary.service.ts
@@ -12,7 +12,6 @@ const ALLOWED_TAGS = [
   'OS',
   'Algorithm',
   'Infra',
-  'Engineering',
   'TypeScript',
   'JavaScript',
   'Java',


### PR DESCRIPTION
https://github.com/boostcampwm-2024/refactor-web05-Denamu/pull/49
enginnering 태그 삭제