### PR TITLE
🐛 fix: detail페이지에서 요악이 없을 경우 발생하는 에러 수정

### DIFF
--- a/client/src/components/common/Card/detail/PostContent.tsx
+++ b/client/src/components/common/Card/detail/PostContent.tsx
@@ -9,7 +9,9 @@ interface PostContentProps {
 }
 
 export const PostContent = React.memo(({ data, onPostClick }: PostContentProps) => {
-  const markdownString = data.summary ? data.summary.replace(/\\n/g, "\n").replace(/\\r/g, "\r") : "";
+  const summary = data.summary;
+  const markdownString = (summary ?? "").replace(/\\n/g, "\n").replace(/\\r/g, "\r");
+
   return (
     <div className="flex flex-col gap-5 mb-10">
       <div
@@ -34,7 +36,9 @@ export const PostContent = React.memo(({ data, onPostClick }: PostContentProps) 
       </div>
       <div className="prose">
         <Markdown>{markdownString}</Markdown>
-        <p className="text-gray-400">💡 인공지능이 요약한 내용입니다. 오류가 포함될 수 있으니 참고 바랍니다.</p>
+        {summary && (
+          <p className="text-gray-400">💡 인공지능이 요약한 내용입니다. 오류가 포함될 수 있으니 참고 바랍니다.</p>
+        )}
       </div>
     </div>
   );

--- a/client/src/pages/PostDetailPage.tsx
+++ b/client/src/pages/PostDetailPage.tsx
@@ -34,6 +34,8 @@ export default function PostDetailPage() {
   if (error || !data) {
     return <NotFound />;
   }
+  const summary = data.data.summary;
+  const markdownString = (summary ?? "").replace(/\\n/g, "\n").replace(/\\r/g, "\r");
 
   return (
     <div ref={modalRef} className="bg-white  overflow-y-auto relative">
@@ -80,8 +82,10 @@ export default function PostDetailPage() {
             )}
           </div>
           <div className="prose">
-            <Markdown>{data.data.summary.replace(/\\n/g, "\n")}</Markdown>
-            <p className="text-gray-400">💡 인공지능이 요약한 내용입니다. 오류가 포함될 수 있으니 참고 바랍니다.</p>
+            <Markdown>{markdownString}</Markdown>
+            {summary && (
+              <p className="text-gray-400">💡 인공지능이 요약한 내용입니다. 오류가 포함될 수 있으니 참고 바랍니다.</p>
+            )}
           </div>
         </div>
       </div>


### PR DESCRIPTION
# 🔨 테스크

detail 페이지에서 요악이 없을 경우 발생하는 에러 수정

# 📋 작업 내용

-   삼항연산자 이용해서 없는경우 빈 문자열이 들어가도록 수정
-   요약이 없으면 인공지능이 요약한 내용이라고 안나오게 수정
