### PR TITLE
♻️ refactor: promise 판별 로직 단순화, 에러 로깅 추가

### DIFF
--- a/feed-crawler/src/claude.service.ts
+++ b/feed-crawler/src/claude.service.ts
@@ -12,7 +12,7 @@ export class ClaudeService {
 
   constructor(
     private readonly tagMapRepository: TagMapRepository,
-    private readonly feedRepository: FeedRepository,
+    private readonly feedRepository: FeedRepository
   ) {
     this.client = new Anthropic({
       apiKey: process.env.AI_API_KEY,
@@ -22,97 +22,60 @@ export class ClaudeService {
   async useCaludeService(feeds: FeedDetail[]) {
     const processedFeeds = await Promise.allSettled(
       feeds.map(async (feed) => {
-        try {
-          const params: Anthropic.MessageCreateParams = {
-            max_tokens: 8192,
-            system: PROMPT_CONTENT,
-            messages: [{ role: "user", content: feed.content }],
-            model: "claude-3-5-haiku-latest",
-          };
-          const message = await this.client.messages.create(params);
-          let responseText: string = message.content[0]["text"];
-          responseText = responseText.replace(/\n/g, "");
-          const result: ClaudeResponse = JSON.parse(responseText);
+        const params: Anthropic.MessageCreateParams = {
+          max_tokens: 8192,
+          system: PROMPT_CONTENT,
+          messages: [{ role: "user", content: feed.content }],
+          model: "claude-3-5-haiku-latest",
+        };
+        const message = await this.client.messages.create(params);
+        let responseText: string = message.content[0]["text"];
+        responseText = responseText.replace(/\n/g, "");
+        const result: ClaudeResponse = JSON.parse(responseText);
 
-          await Promise.all([
-            this.generateTag(feed, result["tags"]),
-            this.summarize(feed, result["summary"]),
-          ]);
-          return {
-            succeeded: true,
-            feed,
-          };
-        } catch (error) {
-          logger.error(
-            `${feed.id}의 태그 생성, 컨텐츠 요약 에러 발생: `,
-            error,
-          );
-          return {
-            succeeded: false,
-            feed,
-          };
-        }
-      }),
+        await Promise.all([
+          this.generateTag(feed, result["tags"]),
+          this.summarize(feed, result["summary"]),
+        ]);
+
+        return feed;
+      })
     );
 
-    // TODO: Refactor
     const successFeeds = processedFeeds
-      .map((result) =>
-        result.status === "fulfilled" && result.value.succeeded === true
-          ? result.value.feed
-          : null,
-      )
-      .filter((result) => result !== null);
+      .filter((result) => result.status === "fulfilled")
+      .map((result) => result.value);
 
-    // TODO: Refactor
     const failedFeeds = processedFeeds
       .map((result, index) => {
         if (result.status === "rejected") {
-          const failedFeed = feeds[index];
-          return {
-            succeeded: false,
-            feed: failedFeed,
-          };
+          logger.error(
+            `[ClaudeService] 피드 분석 도중 에러가 발생했습니다.
+            에러 메시지: ${result.reason.message}
+            스택 트레이스: ${result.reason.stack}`
+          );
+          return feeds[index];
         }
-        return result.status === "fulfilled" && result.value.succeeded === false
-          ? result.value
-          : null;
+        return null;
       })
-      .filter((result) => result !== null && result.succeeded === false)
-      .map((result) => result.feed);
+      .filter((result) => result !== null);
 
     logger.info(
-      `${successFeeds.length}개의 태그 생성 및 컨텐츠 요약이 성공했습니다.\n ${failedFeeds.length}개의 태그 생성 및 컨텐츠 요약이 실패했습니다.`,
+      `${successFeeds.length}개의 태그 생성 및 컨텐츠 요약이 성공했습니다.\n ${failedFeeds.length}개의 태그 생성 및 컨텐츠 요약이 실패했습니다.`
     );
 
     return [...successFeeds, ...failedFeeds];
   }
 
   private async generateTag(feed: FeedDetail, tags: Record<string, number>) {
-    try {
-      const tagList = Object.keys(tags);
-      if (tagList.length === 0) return;
-      await this.tagMapRepository.insertTags(feed.id, tagList);
-      feed.tag = tagList;
-    } catch (error) {
-      logger.error(
-        `[DB] 태그 데이터를 저장하는 도중 에러가 발생했습니다.
-      에러 메시지: ${error.message}
-      스택 트레이스: ${error.stack}`,
-      );
-    }
+    const tagList = Object.keys(tags);
+    if (tagList.length === 0) return;
+    await this.tagMapRepository.insertTags(feed.id, tagList);
+    feed.tag = tagList;
   }
 
   private async summarize(feed: FeedDetail, summary: string) {
-    try {
-      await this.feedRepository.insertSummary(feed.id, summary);
-      feed.summary = summary;
-    } catch (error) {
-      logger.error(
-        `[DB] 게시글 요약 데이터를 저장하는 도중 에러가 발생했습니다.
-      에러 메시지: ${error.message}
-      스택 트레이스: ${error.stack}`,
-      );
-    }
+    await this.feedRepository.insertSummary(feed.id, summary);
+    feed.summary = summary;
   }
 }


### PR DESCRIPTION
# 🔨 테스크

### Promise의 에러 처리에 대해
고민은 아니지만 promise의 에러 처리에 대해 학습할 수 있었다.
promise의 내부에서 try/catch를 사용하는 것이 좋지 않다는 것을 알게 되었고, 메서드 체이닝 catch를 통한 에러 처리를 하는 것이 더 낫다는 것을 학습했다.
그리고 allSettled를 사용하면서 각각의 promise에 rejected 혹은 fulfilled 상태로 접근할 수 있다는 것을 확인했다.
이것을 적용해서 try/catch가 불필요함을 확인하고 삭제했으며, promise가 이행상태인지, 거부 상태인지 판별하여 동작하도록 로직을 수정했다.

이외에 비즈니스 로직 외에 에러가 발생하는 부분을 걱정했는데, 민석님의 피드백대로 그런 에러들도 promise 동작 중 에러 캐치에 잡힐 수 있고 똑같이 reject 상태로 반환된다는 부분도 확인했다.

# 📋 작업 내용

-  Promise 로직 단순화 및 try/catch 삭제

# 📷 스크린 샷(선택 사항)
![스크린샷 2025-02-18 154920](https://github.com/user-attachments/assets/f45e22f3-2999-482e-ab63-c69ead954a35)
![스크린샷 2025-02-18 154950](https://github.com/user-attachments/assets/770e85e8-f667-4d27-95e5-b15f2544b752)
![스크린샷 2025-02-18 155008](https://github.com/user-attachments/assets/18d406c2-3647-4ff9-8ad3-51c36ceca2da)
