### PR TITLE
🐛 fix: 배포 스크립트 배포 로직 변경

### DIFF
--- a/.github/workflows/deploy_client.yml
+++ b/.github/workflows/deploy_client.yml
@@ -16,10 +16,10 @@ jobs:
       - name: ssh connection
         uses: appleboy/ssh-action@v1.1.0
         with:
-          host: ${{ secrets.CLOUD_INSTANCE_HOST }}
-          username: ${{ secrets.CLOUD_INSTANCE_USERNAME }}
-          key: ${{ secrets.SSH_KEY }}
-          port: ${{ secrets.CLOUD_INSTANCE_SSH_PORT }}
+          host: ${{ secrets.CLOUD_PUBLIC_INSTANCE_HOST }}
+          username: ${{ secrets.CLOUD_PUBLIC_INSTANCE_USERNAME }}
+          key: ${{ secrets.CLOUD_PUBLIC_INSTANCE_SSH_KEY }}
+          port: ${{ secrets.CLOUD_PUBLIC_INSTANCE_PORT }}
           script: |
             export NVM_DIR=~/.nvm
             source ~/.nvm/nvm.sh

--- a/.github/workflows/deploy_feed-crawler.yml
+++ b/.github/workflows/deploy_feed-crawler.yml
@@ -16,17 +16,24 @@ jobs:
       - name: ssh connection
         uses: appleboy/ssh-action@v1.1.0
         with:
-          host: ${{ secrets.CLOUD_INSTANCE_HOST }}
-          username: ${{ secrets.CLOUD_INSTANCE_USERNAME }}
-          key: ${{ secrets.SSH_KEY }}
-          port: ${{ secrets.CLOUD_INSTANCE_SSH_PORT }}
+          host: ${{ secrets.CLOUD_PUBLIC_INSTANCE_HOST }}
+          username: ${{ secrets.CLOUD_PUBLIC_INSTANCE_USERNAME }}
+          key: ${{ secrets.CLOUD_PUBLIC_INSTANCE_SSH_KEY }}
+          port: ${{ secrets.CLOUD_PUBLIC_INSTANCE_PORT }}
           script: |
+#           nvm 설정
             export NVM_DIR=~/.nvm
             source ~/.nvm/nvm.sh
-
+            
+#           private 서버로 접속을 위한 ssh key 생성
+            set -e
+            echo "${{ secrets.CLOUD_PRIVATE_INSTANCE_SSH_KEY }}" > /tmp/private_key
+            chmod 600 /tmp/private_key
+            
+#           깃헙 소스코드 업데이트
             cd /var/web05-Denamu
             git pull origin main
-            cd feed-crawler/
+            cd /var/web05-Denmau/feed-crawler/
 
             echo "PORT=${{ secrets.FEED_CRAWLER_PORT }}" > .env
             echo "DB_HOST=${{ secrets.FEED_CRAWLER_DB_HOST }}" >> .env
@@ -41,6 +48,20 @@ jobs:
             echo "REDIS_USERNAME=${{secrets.REDIS_USERNAME}}" >> .env
             echo "REDIS_PASSWORD=${{secrets.REDIS_PASSWORD}}" >> .env
             echo "AI_API_KEY=${{secrets.AI_API_KEY}}" >> .env
-
+            
+#           내부망으로의 전달을 위한 의존성 설치 & 압축 & 전달
             npm ci
+            cd /var
+            tar -czvf app.tar.gz web05-Denamu
+            scp -i /tmp/private_key /var/app.tar.gz root@172.16.0.22:/var/app.tar.gz
+            
+#           private 서버로 접속 후 압축 해제 & 빌드 & 실행 (Heredoc 을 사용해 라인 구분)               
+            ssh -i /tmp/private_key ${{ secrets.CLOUD_PRIVATE_INSTANCE_USER }}@${{ secrets.CLOUD_PRIVATE_INSTANCE_HOST }} << 'EOF'
+            cd /var
+            tar -xzvf app.tar.gz
+            cd /var/web05-Denamu/feed-crawler
             npm run build
+            cd /var/web05-Denamu
+            pm2 delete all
+            pm2 start ecosystem.config.js
+            EOF

--- a/.github/workflows/deploy_server.yml
+++ b/.github/workflows/deploy_server.yml
@@ -16,20 +16,27 @@ jobs:
       - name: ssh connection
         uses: appleboy/ssh-action@v1.1.0
         with:
-          host: ${{ secrets.CLOUD_INSTANCE_HOST }}
-          username: ${{ secrets.CLOUD_INSTANCE_USERNAME }}
-          key: ${{ secrets.SSH_KEY }}
-          port: ${{ secrets.CLOUD_INSTANCE_SSH_PORT }}
+          host: ${{ secrets.CLOUD_PUBLIC_INSTANCE_HOST }}
+          username: ${{ secrets.CLOUD_PUBLIC_INSTANCE_USERNAME }}
+          key: ${{ secrets.CLOUD_PUBLIC_INSTANCE_SSH_KEY }}
+          port: ${{ secrets.CLOUD_PUBLIC_INSTANCE_PORT }}
           script: |
+#           nvm 설정
             export NVM_DIR=~/.nvm
             source ~/.nvm/nvm.sh
 
+#           private 서버로 접속을 위한 ssh key 생성
+            set -e
+            echo "${{ secrets.CLOUD_PRIVATE_INSTANCE_SSH_KEY }}" > /tmp/private_key
+            chmod 600 /tmp/private_key
+            
+#           깃헙 소스코드 업데이트
             cd /var/web05-Denamu
             git pull origin main
-            cd server/
+            cd /var/web05-Denmau/server
 
+#           환경변수 설정
             mkdir -p configs
-
             echo "PORT=${{ secrets.PRODUCT_PORT }}" > configs/.env.db.production
             echo "DB_TYPE=mysql" >> configs/.env.db.production
             echo "DB_DATABASE=${{ secrets.PRODUCT_DB_DATABASE }}" >> configs/.env.db.production
@@ -45,10 +52,19 @@ jobs:
             echo "EMAIL_PASSWORD=${{secrets.EMAIL_PASSWORD}}" >> configs/.env.db.production
             echo "AI_API_KEY=${{secrets.AI_API_KEY}}" >> configs/.env.db.production
 
+#           내부망으로의 전달을 위한 의존성 설치 & 압축 & 전달
             npm ci
+            cd /var
+            tar -czvf app.tar.gz web05-Denamu
+            scp -i /tmp/private_key /var/app.tar.gz root@172.16.0.22:/var/app.tar.gz
+            
+#           private 서버로 접속 후 압축 해제 & 빌드 & 실행 (Heredoc 을 사용해 라인 구분)               
+            ssh -i /tmp/private_key ${{ secrets.CLOUD_PRIVATE_INSTANCE_USER }}@${{ secrets.CLOUD_PRIVATE_INSTANCE_HOST }} << 'EOF'
+            cd /var
+            tar -xzvf app.tar.gz
+            cd /var/web05-Denamu/server
             npm run build
-
-            cd ..
-
+            cd /var/web05-Denamu
             pm2 delete all
             pm2 start ecosystem.config.js
+            EOF


### PR DESCRIPTION
# 📋 작업 내용
## 개요
보안 향상을 위한 단일 진입점 (NGINX)를  제외한 모든 리소스들을 Private 으로 옮기자는 의사결정이 진행됨.

### 서버 이전 (Public, Private)
**인프라 구성이 변경되었습니다.** [(디테일한 패스워드나 주소와 같은 내용들은 노션 프라이빗 문서 참고해주세요.)](https://www.notion.so/DB-64048d5ecfcd4b09a64faca1825b125b?pvs=4)

- VPC 
  - Public Subnet / Public Server (1Core 1GB)
    - NGINX
    - Static Files (FE build files, Static images.... etc)
  - Private Subnet / Private Server (2Core 4GB)
    - WAS
    - Redis
    - MySQL

### 서버 이전으로 인한 CI / CD 스크립트 변경
비용 문제로 인해 NAT를 유지하기 않기로 결정됨에 따라 SCP를 사용한 파일 전달의 필요성 대두.
그리하여 `feed-crawler`, `server`, `client`의 CI/CD 스크립트가 변경되었습니다.

별도의 의존성 설치후 프라이빗 서버로 전달이 필요한 `feed-crawler`, `server` 같은 경우는 다음과 같은 흐름으로 작업을 수행합니다.
> `git pull` -> `npm ci` -> `프로젝트 압축` ->`scp 를 사용한 압축 파일 전송` -> `ssh proxy 접속` -> `압축 해제` -> `npm run build` -> `pm2 restart`

Public Server가 비교적 저렴한 사양의 인스턴스를 사용하게 될 것을 고려해 **빌드는 Private 인스턴스에서 실행하도록 처리** 하였습니다.

### Github Actions Secrets 변수 추가
아래 키들이 추가되었습니다.
```
CLOUD_PUBLIC_INSTANCE_HOST
CLOUD_PUBLIC_INSTANCE_USERNAME
CLOUD_PUBLIC_INSTANCE_PORT
CLOUD_PUBLIC_INSTANCE_SSH_KEY

CLOUD_PRIVATE_INSTANCE_HOST
CLOUD_PRIVATE_INSTANCE_USERNAME
CLOUD_PRIVATE_INSTANCE_PORT
CLOUD_PRIVATE_INSTANCE_SSH_KEY
```