### PR TITLE
📦 chore: jest timeout docker 시간 설정

### DIFF
--- a/feed-crawler/test/jest-e2e.json
+++ b/feed-crawler/test/jest-e2e.json
@@ -8,5 +8,6 @@
   "rootDir": "..",
   "coverageDirectory": "test/coverage",
   "globalSetup": "./test/setup/jest.global-setup.ts",
-  "setupFilesAfterEnv": ["./test/setup/truncate-tables.setup.ts"]
+  "setupFilesAfterEnv": ["./test/setup/truncate-tables.setup.ts"],
+  "testTimeout": 10000
 }

--- a/feed-crawler/test/jest-integration.json
+++ b/feed-crawler/test/jest-integration.json
@@ -8,5 +8,6 @@
   "rootDir": "..",
   "coverageDirectory": "test/coverage",
   "globalSetup": "./test/setup/jest.global-setup.ts",
-  "setupFilesAfterEnv": ["./test/setup/truncate-tables.setup.ts"]
+  "setupFilesAfterEnv": ["./test/setup/truncate-tables.setup.ts"],
+  "testTimeout": 10000
 }

--- a/feed-crawler/test/jest-unit.json
+++ b/feed-crawler/test/jest-unit.json
@@ -6,5 +6,6 @@
   },
   "testEnvironment": "node",
   "rootDir": "..",
-  "coverageDirectory": "test/coverage"
+  "coverageDirectory": "test/coverage",
+  "testTimeout": 10000
 }

--- a/server/test/jest-e2e.json
+++ b/server/test/jest-e2e.json
@@ -10,5 +10,6 @@
   "setupFilesAfterEnv": ["./test/jest.setup.ts"],
   "globalSetup": "./test/integration-test-global-setup.ts",
   "globalTeardown": "./test/integration-test-global-teardown.ts",
-  "maxWorkers": 1
+  "maxWorkers": 1,
+  "testTimeout": 10000
 }

--- a/server/test/jest-integration.json
+++ b/server/test/jest-integration.json
@@ -10,5 +10,6 @@
   "setupFilesAfterEnv": ["./test/jest.setup.ts"],
   "globalSetup": "./test/integration-test-global-setup.ts",
   "globalTeardown": "./test/integration-test-global-teardown.ts",
-  "maxWorkers": 1
+  "maxWorkers": 1,
+  "testTimeout": 10000
 }

--- a/server/test/jest-unit.json
+++ b/server/test/jest-unit.json
@@ -6,5 +6,6 @@
   "transform": {
     "^.+\\.(t|j)s$": "ts-jest"
   },
-  "coverageDirectory": "test/coverage"
+  "coverageDirectory": "test/coverage",
+  "testTimeout": 10000
 }


### PR DESCRIPTION
# 🔨 테스크

### 작업 사유

사양이 낮은 컴퓨터(ex. github cicd server, 노트북 등)에서 Docker를 이용하여 임시 컨테이너 만드는 테스트 코드가 사양 문제로 인해 느리게 수행되는 문제가 있었다.
github ci/cd server에서 테스트 실패가 뜰 경우 re-run job을 수행해야 해서 생산성이 저하됐다.


# 📋 작업 내용
-   jest time out 설정 (default 5,000ms -> 10,000ms)
