### PR TITLE
[긴급] 🐛 fix: CI/CD 버그 수정 및 사용되지 않는 환경 변수 제거

### DIFF
--- a/.github/workflows/deploy_feed-crawler.yml
+++ b/.github/workflows/deploy_feed-crawler.yml
@@ -29,21 +29,20 @@ jobs:
           script: |
             export NVM_DIR=~/.nvm
             source ~/.nvm/nvm.sh
-            
+
             set -e
             echo "${{ secrets.CLOUD_PRIVATE_INSTANCE_SSH_KEY }}" > /tmp/private_key
             chmod 600 /tmp/private_key
-            
+
             cd /var/web05-Denamu
             git pull origin main
             cd /var/web05-Denamu/feed-crawler/
 
-            echo "PORT=${{ secrets.FEED_CRAWLER_PORT }}" > .env
+            echo "DB_PORT=${{ secrets.FEED_CRAWLER_DB_PORT }}" > .env
             echo "DB_HOST=${{ secrets.FEED_CRAWLER_DB_HOST }}" >> .env
             echo "DB_NAME=${{ secrets.FEED_CRAWLER_DB_NAME }}" >> .env
             echo "DB_USER=${{ secrets.FEED_CRAWLER_DB_USER }}" >> .env
             echo "DB_PASS=${{ secrets.FEED_CRAWLER_DB_PASSWORD }}" >> .env
-            echo "DB_TABLE=${{ secrets.FEED_CRAWLER_DB_TABLE }}" >> .env
             echo "TIME_INTERVAL=${{ vars.FEED_CRAWLER_TIME_INTERVAL }}" >> .env
             echo "TEST_TIME_INTERVAL=${{ vars.FEED_CRAWLER_TEST_TIME_INTERVAL }}" >> .env
             echo "REDIS_HOST=${{secrets.REDIS_HOST }}" >> .env
@@ -51,29 +50,30 @@ jobs:
             echo "REDIS_USERNAME=${{secrets.REDIS_USERNAME}}" >> .env
             echo "REDIS_PASSWORD=${{secrets.REDIS_PASSWORD}}" >> .env
             echo "AI_API_KEY=${{secrets.AI_API_KEY}}" >> .env
-            
+            echo "AI_RATE_LIMIT_COUNT=${{ secrets.AI_RATE_LIMIT_COUNT }}" >> .env
+
             npm ci
             cd /var/web05-Denamu
             tar -czvf /tmp/app_feed_crawler.tar.gz feed-crawler
             scp -i /tmp/private_key /tmp/app_feed_crawler.tar.gz root@172.16.0.22:/tmp/app_feed_crawler.tar.gz
                            
             ssh -i /tmp/private_key ${{ secrets.CLOUD_PRIVATE_INSTANCE_USERNAME }}@${{ secrets.CLOUD_PRIVATE_INSTANCE_HOST }} << 'EOF'
-            
+
             export NVM_DIR="$HOME/.nvm"
             [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
             nvm use 22
-            
+
             cd /var/web05-Denamu
             pm2 delete all
-            
+
             cd /tmp
             tar -xzvf app_feed_crawler.tar.gz
             rm -rf /var/web05-Denamu/feed-crawler
             mv /tmp/feed-crawler /var/web05-Denamu
-            
+
             cd /var/web05-Denamu/feed-crawler
             npm run build
             cd /var/web05-Denamu
-            
+
             pm2 start ecosystem.config.js
             EOF

--- a/.github/workflows/deploy_server.yml
+++ b/.github/workflows/deploy_server.yml
@@ -29,7 +29,7 @@ jobs:
           script: |
             export NVM_DIR=~/.nvm
             source ~/.nvm/nvm.sh
-       
+
             set -e
             echo "${{ secrets.CLOUD_PRIVATE_INSTANCE_SSH_KEY }}" > /tmp/private_key
             chmod 600 /tmp/private_key
@@ -37,7 +37,7 @@ jobs:
             cd /var/web05-Denamu
             git pull origin main
             cd /var/web05-Denamu/server
-       
+
             mkdir -p configs
             echo "PORT=${{ secrets.PRODUCT_PORT }}" > configs/.env.db.production
             echo "DB_TYPE=mysql" >> configs/.env.db.production
@@ -57,22 +57,22 @@ jobs:
             npm ci
             cd /var/web05-Denamu
             tar -czvf /tmp/app_server.tar.gz server
-            scp -i /tmp/private_key /tmp/app_server.tar.gz root@172.16.0.22:/tmp/app_server.tar.gz
+            scp -i /tmp/private_key /tmp/app_server.tar.gz root@${{ secrets.CLOUD_PRIVATE_INSTANCE_HOST }}:/tmp/app_server.tar.gz
 
             ssh -i /tmp/private_key ${{ secrets.CLOUD_PRIVATE_INSTANCE_USERNAME }}@${{ secrets.CLOUD_PRIVATE_INSTANCE_HOST }} << 'EOF'
-            
+
             export NVM_DIR="$HOME/.nvm"
             [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
             nvm use 22
             node -v
             cd /var/web05-Denamu
             pm2 delete all
-            
+
             cd /tmp
             tar -xzvf app_server.tar.gz
             rm -rf /var/web05-Denamu/server
             mv /tmp/server /var/web05-Denamu
-            
+
             cd /var/web05-Denamu/server
             npm run build
             cd /var/web05-Denamu

--- a/feed-crawler/src/common/mysql-access.ts
+++ b/feed-crawler/src/common/mysql-access.ts
@@ -20,6 +20,7 @@ export class MySQLConnection implements DatabaseConnection {
   private createPool() {
     return mysql.createPool({
       host: process.env.DB_HOST,
+      port: parseInt(process.env.DB_PORT),
       user: process.env.DB_USER,
       password: process.env.DB_PASS,
       database: process.env.DB_NAME,


### PR DESCRIPTION
# 🔨 테스크

### CI/CD 버그 발견
마지막 Feed Crawler에서 AI Queue를 사용하도록 한 부분에서 환경변수 AI_RATE_LIMIT_COUNT가 추가 되었는데, 추가를 안 했습니다. 죄송합니다 ㅠ.ㅠ

발표 전이라 조금 리스크는 있겠지만, 환경변수 이름 한 가지를 바꿨습니다. 확실하게 바꿔놨습니다!

# 📋 작업 내용
- Feed Crawler 확인해보니 환경변수 명이 PORT -> DB_PORT로 바뀌어야 했음. 그래서 바꿈
- Feed Crawler에 AI_RATE_LIMIT_COUNT 환경변수 추가
-   사용하지 않는 환경 변수 15개 가량 Github Repository에서 제거
ex) RSS_NOTIFIER_*, HOST, PORT, SSH_KEY, SSH_PRIVATE_INSTANCE_KEY, USERNAME 등등... 안 쓰이는 것들 제거함
