### PR TITLE
🐛 fix: cicd 스크립트 인프라 구조에 맞게 수정

### DIFF
--- a/.github/workflows/deploy_feed-crawler.yml
+++ b/.github/workflows/deploy_feed-crawler.yml
@@ -20,19 +20,9 @@ jobs:
           username: ${{ secrets.CLOUD_PUBLIC_INSTANCE_USERNAME }}
           key: ${{ secrets.CLOUD_PUBLIC_INSTANCE_SSH_KEY }}
           port: ${{ secrets.CLOUD_PUBLIC_INSTANCE_PORT }}
-          # 1.nvm 설정
-          # 2.private 서버로 접속을 위한 ssh key 생성
-          # 3. 깃헙 소스코드 업데이트
-          # 4. 환경변수 설정
-          # 5. 내부망으로의 전달을 위한 의존성 설치 & 압축 & 전달
-          # 6. private 서버로 접속 후 압축 해제 & 기존 버전 제거 & 새 버전 적용 & 빌드 & 실행 (Heredoc 을 사용해 라인 구분)
           script: |
             export NVM_DIR=~/.nvm
             source ~/.nvm/nvm.sh
-
-            set -e
-            echo "${{ secrets.CLOUD_PRIVATE_INSTANCE_SSH_KEY }}" > /tmp/private_key
-            chmod 600 /tmp/private_key
 
             cd /var/web05-Denamu
             git pull origin main
@@ -53,27 +43,8 @@ jobs:
             echo "AI_RATE_LIMIT_COUNT=${{ vars.AI_RATE_LIMIT_COUNT }}" >> .env
 
             npm ci
-            cd /var/web05-Denamu
-            tar -czvf /tmp/app_feed_crawler.tar.gz feed-crawler
-            scp -i /tmp/private_key /tmp/app_feed_crawler.tar.gz root@172.16.0.22:/tmp/app_feed_crawler.tar.gz
-                           
-            ssh -i /tmp/private_key ${{ secrets.CLOUD_PRIVATE_INSTANCE_USERNAME }}@${{ secrets.CLOUD_PRIVATE_INSTANCE_HOST }} << 'EOF'
-
-            export NVM_DIR="$HOME/.nvm"
-            [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
-            nvm use 22
-
-            cd /var/web05-Denamu
-            pm2 delete all
-
-            cd /tmp
-            tar -xzvf app_feed_crawler.tar.gz
-            rm -rf /var/web05-Denamu/feed-crawler
-            mv /tmp/feed-crawler /var/web05-Denamu
-
-            cd /var/web05-Denamu/feed-crawler
             npm run build
             cd /var/web05-Denamu
-
+            
+            pm2 delete all
             pm2 start ecosystem.config.js
-            EOF

--- a/.github/workflows/deploy_server.yml
+++ b/.github/workflows/deploy_server.yml
@@ -20,20 +20,10 @@ jobs:
           username: ${{ secrets.CLOUD_PUBLIC_INSTANCE_USERNAME }}
           key: ${{ secrets.CLOUD_PUBLIC_INSTANCE_SSH_KEY }}
           port: ${{ secrets.CLOUD_PUBLIC_INSTANCE_PORT }}
-          # 1.nvm 설정
-          # 2.private 서버로 접속을 위한 ssh key 생성
-          # 3. 깃헙 소스코드 업데이트
-          # 4. 환경변수 설정
-          # 5. 내부망으로의 전달을 위한 의존성 설치 & 압축 & 전달
-          # 6. private 서버로 접속 후 압축 해제 & 기존 버전 제거 & 새 버전 적용 & 빌드 & 실행 (Heredoc 을 사용해 라인 구분)
           script: |
             export NVM_DIR=~/.nvm
             source ~/.nvm/nvm.sh
 
-            set -e
-            echo "${{ secrets.CLOUD_PRIVATE_INSTANCE_SSH_KEY }}" > /tmp/private_key
-            chmod 600 /tmp/private_key
-                  
             cd /var/web05-Denamu
             git pull origin main
             cd /var/web05-Denamu/server
@@ -55,27 +45,8 @@ jobs:
             echo "AI_API_KEY=${{secrets.AI_API_KEY}}" >> configs/.env.db.production
 
             npm ci
-            cd /var/web05-Denamu
-            tar -czvf /tmp/app_server.tar.gz server
-            scp -i /tmp/private_key /tmp/app_server.tar.gz root@${{ secrets.CLOUD_PRIVATE_INSTANCE_HOST }}:/tmp/app_server.tar.gz
-
-            ssh -i /tmp/private_key ${{ secrets.CLOUD_PRIVATE_INSTANCE_USERNAME }}@${{ secrets.CLOUD_PRIVATE_INSTANCE_HOST }} << 'EOF'
-
-            export NVM_DIR="$HOME/.nvm"
-            [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
-            nvm use 22
-            node -v
+            npm run build
+            
             cd /var/web05-Denamu
             pm2 delete all
-
-            cd /tmp
-            tar -xzvf app_server.tar.gz
-            rm -rf /var/web05-Denamu/server
-            mv /tmp/server /var/web05-Denamu
-
-            cd /var/web05-Denamu/server
-            npm run build
-            cd /var/web05-Denamu
-
             pm2 start ecosystem.config.js
-            EOF


### PR DESCRIPTION
# 📋 작업 내용
### 서버 축소 이전 계획에 따른 CI/CD 스크립트 변경
변경된 인프라 구조에 맞게 CI/CD 스크립트를 수정했습니다.

### 시크릿 변수값 변경
`FEED_CRAWLER_DB_HOST`, `REDIS_HOST`, `REDIS_USERNAME`
`PRODUCT_DB_HOST`, `PRODUCT_DB_HOST`. PRODUCT_USERNAME`
시크릿 변수들이 변경되었습니다.

# 👀 중점적으로 확인 해주셔야 할 부분
### 퍼블릭 서버 스토리지 확장
현재 사용중인 퍼블릭 서버의 스토리지 사이즈를 10GB -> 30GB로 업그레이드 하였습니다. [확장 후 디스크 파티션을 합쳐주어](https://guide.ncloud-docs.com/docs/server-storage-modify-vpc) 적용될 수 있도록 처리하였습니다.

### `nginx.conf` 임시 파일 사용
현재 `nginx/nginx.conf` 의 내용은 Docker compose 에서 사용할 별칭등이 포함된 상태라 현재 이 설정 파일을 바로 적용시킬 수 없었습니다.

그리하여 public 인스턴스내 /var 경로에 `nginx.conf` 임시 세팅파일을 사용하도록 처리하였습니다.
본 저장소에서 관리중인 nginx 설정파일 적용은 @Jo-Minseok 님께서 **도커 작업이 끝나면 이 부분 인지하고 바꿔주시면** 감사하겠습니다!